### PR TITLE
have mbind() return NULL if all arguments are NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 4.80.1
-Date: 2018-02-28
+Version: 4.80.2
+Date: 2018-03-13
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
@@ -44,4 +44,4 @@ License: LGPL-3 | file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
-ValidationKey: 84449590
+ValidationKey: 84529606

--- a/R/mbind.R
+++ b/R/mbind.R
@@ -45,6 +45,10 @@ mbind <- function(...) {
       warning("You are trying to mbind an empty magclass object. Is that really intended?")
     }
   }
+  
+  # if all inputs are NULL, return NULL
+  if (0 == length(inputs))
+    return(NULL)
 
   regio <- NULL
   cells <- NULL


### PR DESCRIPTION
In at least two places in the `remind` package, `mbind()` can be called with all arguments being `NULL`. So far, this brakes (`NULL` arguments are removed from the list of inputs, which is then empty, and accessing the first element is attempted).
Since `mbind(x, NULL)` returns `NULL`, it seems natural that `mbind(NULL, NULL)` would return `NULL` as well.