### PR TITLE
 Metadata bugfixes 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 4.87.2
-Date: 2018-07-18
+Version: 4.87.3
+Date: 2018-07-23
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
@@ -44,5 +44,5 @@ License: LGPL-3 | file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
-ValidationKey: 86380560
+ValidationKey: 86422655
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 4.87.3
-Date: 2018-07-23
+Version: 4.87.4
+Date: 2018-07-24
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
@@ -44,5 +44,5 @@ License: LGPL-3 | file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
-ValidationKey: 86422655
+ValidationKey: 86445264
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 4.87.1
+Version: 4.87.2
 Date: 2018-07-18
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
@@ -44,5 +44,5 @@ License: LGPL-3 | file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
-ValidationKey: 86362830
+ValidationKey: 86380560
 

--- a/R/getMetadata.R
+++ b/R/getMetadata.R
@@ -175,8 +175,10 @@ getMetadata <- function(x, type=NULL) {
   .setVersion <- function(pre,ver) {
     if (is.character(ver)) {
       tmp <- vector()
-      if (grepl(";",ver,fixed=TRUE)) {
-        ver <- unlist(strsplit(ver,";",fixed=TRUE))
+      if (length(ver)==1) {
+        if (grepl(";",ver,fixed=TRUE)) {
+          ver <- unlist(strsplit(ver,";",fixed=TRUE))
+        }
       }
       for (i in 1:length(ver)) {
         if (grepl("[[:digit:]]",ver[i]) & grepl("[[:alpha:]]",ver[i])) {
@@ -197,11 +199,10 @@ getMetadata <- function(x, type=NULL) {
             if (as.character(names(pre)[j])==as.character(names(tmp)[i])) {
               dbl[k] <- i
               k <- k+1
-              if (as.package_version(tmp[i]) > as.package_version(pre[j])) {
-                pre[j] <- tmp[i]
-              }else if (as.package_version(tmp[i]) < as.package_version(pre[j])) {
+              if (as.package_version(tmp[i]) < as.package_version(pre[j])) {
                 warning(paste("The provided version",tmp[i],"for the",names(tmp[i]),"package is behind the previously used version (",pre[j],")"))
               }
+              pre[j] <- tmp[i]
             }
           }
         }

--- a/R/getMetadata.R
+++ b/R/getMetadata.R
@@ -147,8 +147,10 @@ getMetadata <- function(x, type=NULL) {
       else if (data.tree::isLeaf(new) & is.null(new$children)) {
         if (is(old,"Node")){
           #root node is set to ROOT when calcHistory is merged in updateMetadata, so it shall be replaced by value
-          if (old$name=="ROOT")  old$name <- new$name
-          else {
+          if (old$name=="ROOT") {
+            old$name <- new$name
+            return(old)
+          }else {
             c <- data.tree::Clone(old)
             new$AddChildNode(c)
           }
@@ -159,8 +161,10 @@ getMetadata <- function(x, type=NULL) {
       if (length(new)==1){
         if (is.null(old))  return(data.tree::Node$new(new))
         if (is(old,"Node")){
-          if (old$name=="ROOT")  old$name <- new
-          else{
+          if (old$name=="ROOT") {
+            old$name <- new
+            return(old)
+          }else {
             c <- data.tree::Clone(old)
             new <- data.tree::Node$new(new)
             new$AddChildNode(c)

--- a/R/read.magpie.R
+++ b/R/read.magpie.R
@@ -181,7 +181,7 @@ read.magpie <- function(file_name,file_folder="",file_type=NULL,as.array=FALSE,o
             i <- i+1
             #isolate the metadata field names
             tmp2 <- unlist(strsplit(tmp, meta.char, fixed=TRUE))[2]
-            field[i] <- trimws(unlist(strsplit(tmp2,": ",fixed=TRUE))[1])
+            field[i] <- trimws(unlist(strsplit(tmp2,":",fixed=TRUE))[1])
             #calcHistory must be reconstructed from a character to a Node object
             if(field[i]=="calcHistory"){
               tmp <- readLines(zz,1)

--- a/R/updateMetadata.R
+++ b/R/updateMetadata.R
@@ -130,7 +130,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   
   #Function buildTree constructs the calcHistory data tree 
   buildTree <- function(x,y=NULL,n,cH){
-    if (length(sys.calls()) < n)  return(NULL)
+    if (length(sys.calls()) < n)  cH <- "merge"
     if (cH=="update"){
       rootNode <- newCall(n)
       if (is.null(y)){
@@ -198,7 +198,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
     return(x)
   }
   
-  #Function runs recursively for each magpie object in y
+  #Run updateMetadata recursively for each magpie object in y
   if (is.list(y)){
     for (i in 1:(length(y)-1)){
       if (is.magpie(y[[i]])){

--- a/R/updateMetadata.R
+++ b/R/updateMetadata.R
@@ -46,9 +46,10 @@
 #' @param note A string or list of strings for attaching notes (e.g. instructions, warnings, etc.) to the data.
 #' Possible arguments are "keep", "copy", "merge", clear", or a new note can be entered here as a character string. 
 #' By default, "keep" if no y argument, or "copy" if y is provided.
-#' @param version A named vector containing the version number(s) of the software used. Each element should 
-#' indicate the full version number (e.g. 1.49.0) and the name should indicate the software package (e.g. madrat). 
-#' Possible arguments are "keep" (default), "copy", "update", and "clear".
+#' @param version A named vector containing the name(s) and version number(s) of the software used. Possible 
+#' arguments are "keep" (default), "copy", "update", "clear", or a character vector (package names and numbers 
+#' can be provided as a named vector, in concatenated strings with a space separator, or in a single string with 
+#' a ';' between each package).
 #' @param n If calcHistory is to be updated, this integer indicates how many frames ahead in the stack to 
 #' find the function to append to the the object's calcHistory. n=1 by default.
 #' @return updateMetadata returns the magpie object x with metadata modified as desired.
@@ -60,8 +61,8 @@
 #' @importFrom methods getPackageName
 #' 
 updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), source=ifelse(is.null(y),"keep","merge"), 
-                           calcHistory=ifelse(is.null(y),"keep","merge"), user="update", date="update", description=ifelse(is.null(y),"keep","copy"), 
-                           note=ifelse(is.null(y),"keep","copy"), version="keep", n=1) {
+                           calcHistory=ifelse(is.null(y),"keep","merge"), user="update", date="update", description=ifelse(is.null(y),"keep","merge"), 
+                           note=ifelse(is.null(y),"keep","merge"), version=ifelse(is.null(y),"keep","merge"), n=1) {
 
   if(!withMetadata()) return(x)
   if (!requireNamespace("data.tree", quietly = TRUE)) stop("The package data.tree is required for metadata handling!")
@@ -129,6 +130,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   
   #Function buildTree constructs the calcHistory data tree 
   buildTree <- function(x,y=NULL,n,cH){
+    if (length(sys.calls()) < n)  return(NULL)
     if (cH=="update"){
       rootNode <- newCall(n)
       if (is.null(y)){
@@ -182,29 +184,35 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   
   #Function for merging metadata from 2 or more objects
   mergeFields <- function(x,y) {
-    if (is.character(x)){
-      if (is.character(y))  x <- list(x,y)
-      else if (is.list(y))  x <- append(list(x),y)
-    }else if (is.list(x)){
-      if (is.character(y))  x <- append(x,list(y))
-      else if (is.list(y))  x <- append(x,y)
-    }else if (is.character(y) | is.list(y))  x <- y
+    if (!is.null(x)) {
+      if (!is.null(y)) {
+        if(!is.list(x)) {
+          if (is.list(y))  x <- append(list(x),y)
+          else  x <- list(x,y)
+        }else {
+          if (is.list(y))  x <- append(x,y)
+          else  x <- append(x,list(y))
+        }
+      }
+    }else if (!is.null(y))  return(y)
     return(x)
   }
   
-  Mx <- getMetadata(x)
-  #Recursive function to merge metadata from a list of magpie objects.
+  #Function runs recursively for each magpie object in y
   if (is.list(y)){
-    My <- list()
-    for (i in 1:length(y)){
+    for (i in 1:(length(y)-1)){
       if (is.magpie(y[[i]])){
-        My[[i]] <- getMetadata(y[[i]])
-      }else  stop("All list components of y must be magpie objects!")
+        x <- updateMetadata(x, y[[i]], unit, source, calcHistory="keep", user, date, description, version, n=n+1)
+      }
     }
-  }else if (!is.null(y) & !is.magpie(y)){
+    My <- getMetadata(y[[length(y)]])
+  }else if (is.magpie(y)) {
+    My <- getMetadata(y)
+  }else if (!is.null(y)){
     y <- NULL
     warning("y argument must be a magpie object or a list of magpie objects!")
-  }else  My <- getMetadata(y)
+  }
+  Mx <- getMetadata(x)
   
   if (is.null(unit))  unit <- "keep"
   if (unit=="copy"){
@@ -225,9 +233,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
     Mx$source <- source
   }else if (source=="merge"){
     if (!is.null(y)){
-      if (!is.null(My$source)){
-        Mx$source <- My$source
-      }
+      Mx$source <- mergeFields(Mx$source,My$source)
     }else  warning("Source cannot be merged without a second magpie argument provided!")
   }else if (source=="copy"){
     if (!is.null(y)){
@@ -302,7 +308,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   }else if (description=="update") {
     warning("Update is an invalid argument for description! Please specify keep, copy, merge, or clear.")
   }else if (description=="merge"){
-    if (!is.null(y))  mergeFields(Mx$description,My$description)
+    if (!is.null(y))  Mx$description <- mergeFields(Mx$description,My$description)
     else  warning("description cannot be merged without a second magpie argument provided!")
   }else if (description!="keep"){
     if (is.character(description))  Mx$description <- description
@@ -318,7 +324,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   }else if (note=="clear") {
     Mx$note <- NULL
   }else if (note=="merge"){
-    if (!is.null(y))  mergeFields(Mx$note,My$note)
+    if (!is.null(y))  Mx$note <- mergeFields(Mx$note,My$note)
     else  warning("note cannot be merged without a second magpie argument provided!")
   }else if (note=="update") {
     warning("Update is an invalid argument for note! Please specify keep, copy, merge, or clear.")
@@ -337,7 +343,7 @@ updateMetadata <- function(x, y=NULL, unit=ifelse(is.null(y),"keep","update"), s
   }else if (version=="clear") {
     Mx$version <- NULL
   }else if (version=="merge") {
-    warning("merge is an invalid argument for version!")
+    Mx$version <- My$version
   }else if (version=="update") {
     warning("update is an invalid argument for version!")
   }else if (version!="keep") {

--- a/R/write.magpie.R
+++ b/R/write.magpie.R
@@ -165,14 +165,13 @@ write.magpie <- function(x,file_name,file_folder="",file_type=NULL,append=FALSE,
       }
       if(!is.null(metadata$note)) {
         writeLines(paste(char,paste0(mchar,"note:"),metadata$note[1]),file)
+        if (length(metadata$note)>1)  writeLines(paste(char,"\t",paste(metadata$note[-1])),file)
         writeLines(char,file)
-        if (length(metadata$note)>1)  writeLines(paste(char,"\t",paste(metadata$note[-1],collapse="\n\t")),file)
       }
-      if(!is.null(metadata$source)){
+      if(!is.null(metadata$source)) {
         writeLines(paste0(char," ",mchar,"source:"),file)
-        writeLines(char,file)
         if(is.list(metadata$source)) {
-          for(i in 1:length(metadata$source)){
+          for(i in 1:length(metadata$source)) {
             if(is(metadata$source[[i]],"bibentry"))  writeLines(paste(char,toBibtex(metadata$source[[i]])),file)
             else if(is(metadata$source[[i]],"Bibtex"))  writeLines(paste(char,metadata$source[[i]]),file)
           }
@@ -182,9 +181,9 @@ write.magpie <- function(x,file_name,file_folder="",file_type=NULL,append=FALSE,
         }
         writeLines(char,file)
       }
-      if(is(metadata$calcHistory,"Node")){
+      if(is(metadata$calcHistory,"Node")) {
         calcHistory <- as.character(as.data.frame(metadata$calcHistory)[[1]])
-        writeLines(paste0(char," ",mchar,"calcHistory:","\n",char),file)
+        writeLines(paste0(char," ",mchar,"calcHistory:"),file)
         writeLines(paste(char,calcHistory),file,useBytes=TRUE)
         writeLines(char,file)
       }


### PR DESCRIPTION
Reimplemented recursive handling of multiple magpie objects in updateMetadata, allowing (but not forcing) use of units class, improved metadata merging and filtering out duplicate entries for note & description