### PR TITLE
Adding exact data queries in magpie objects, along with ordered vector searches with "AND" and "OR" operators

### DIFF
--- a/R/magpie-class.R
+++ b/R/magpie-class.R
@@ -109,7 +109,6 @@ setClass("magpie",contains="array",prototype=array(0,c(0,0,0)))
       warning("Your dimnames in dim=",dim," contain duplicates! This might lead to erronous results and bad code performance. Please try to avoid duplicates in dimnames under all circumstances!")
     }
   }
-  
   pmatch1 <- ifelse(pmatch==TRUE | pmatch=="right",".*","")
   pmatch2 <- ifelse(pmatch==TRUE | pmatch=="left",".*","")
   if(is.numeric(subdim) & pmatch==FALSE & length(i) == length(subdim)){
@@ -192,7 +191,7 @@ setClass("magpie",contains="array",prototype=array(0,c(0,0,0)))
 #' @exportMethod [
 setMethod("[",
           signature(x = "magpie"),
-          function (x, i, j, k,subdim=FALSE,query=FALSE,drop=FALSE,pmatch=FALSE,invert=FALSE) 
+          function (x, i, j, k,dim=FALSE,query=FALSE,drop=FALSE,pmatch=FALSE,invert=FALSE) 
           {
             if(is.null(dim(x))) return(x@.Data[i])
             if(!missing(i)) {
@@ -215,7 +214,7 @@ setMethod("[",
             }
             if(!missing(k)) {
               if(is.factor(k)) k <- as.character(k)
-              if(is.character(k)) k <- .dimextract(x,k,3,subdim=subdim,query=query,pmatch=pmatch,invert=invert)
+              if(is.character(k)) k <- .dimextract(x,k,3,subdim=dim,query=query,pmatch=pmatch,invert=invert)
             }
             if(ifelse(missing(i),FALSE,is.array(i) | any(abs(i)>dim(x)[1]))) {
               #indices are supplied as array, return data as numeric


### PR DESCRIPTION
Hi Jan,

I was just experimenting with magpies and I believe it is not possible to natively query exact data dimensions in magpie objects. As an example, suppose we have a magpie object `x` with the following `getNames(x)` ouput:

```
[1] "rcp26.1.1" "rcp26.1.2" 
[3] "rcp6.2.3" "rcp6.1.1"
``` 
Suppose I wanted to query all columns with a `1` in their 3rd sub-dimension, I would use `getNames(x[,,"1"])` and the result would be:
```
[1] "rcp26.1.1" "rcp26.1.2" 
[3] "rcp6.1.1"
``` 
However, I would like `1` to be in the 3rd sub-dimension. As far as I understand, this is not possible to do natively with magpies. Rather, one must do some other process with the `getNames(x)` and its `dim` argument.

Just to make this easier and more compact, I introduced some edits to the `magpie-class.R` file. You can see them in the commits and I would consider them minor.

In regards to the above problem, you can execute `getNames(x[,,"1", dim = 3])` and the output would be as desired:
```
[1] "rcp26.1.1" "rcp6.1.1"
``` 
In addition, one can also input the search string for data as a vector and the `dim` as a vector. Here, it is possible to input a query into a magpie, which can be "AND" or "OR". These behave very much like simple SQL queries.  For example, one can execute `x[,,c("rcp26","1"), dim = c(1,3), query = "AND"]` and this will produce the data columns which have "rcp26" on their 1st sub-dimension and "3" on their 3rd sub-dimension:
```
[1] "rcp26.1.1"
``` 
The default argument for `query` is "AND", so one would get the same result running: `x[,,c("rcp26","1"), dim = c(1,3)]`. One can also execute `x[,,c("rcp26","1"), dim = c(1,3), query = "OR"]` and this will function like an "OR" operator in contrast to the "AND" operator above:
```
[1] "rcp26.1.1" "rcp26.1.2" 
[3] "rcp6.1.1"
``` 
I hope this is okay. I had asked some people and they had mentioned that such a thing does not exist in magpie, that's why I decided to do this. But if this already exists then my bad! :)

PS: If this change is alright and you deem it to be useful, I can also extend it the case where `pmatch = TRUE`. For now I just kept it simple to cases where `pmatch = FALSE`