### PR TITLE
bugfix: return object only if not written to file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 5.2.1
-Date: 2019-10-11
+Version: 5.2.2
+Date: 2019-11-01
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),
@@ -49,4 +49,4 @@ LazyData: true
 Encoding: UTF-8
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
-ValidationKey: 9471780
+ValidationKey: 9500922

--- a/man/write.reportProject.Rd
+++ b/man/write.reportProject.Rd
@@ -21,7 +21,7 @@ Unit is a name of the unit without ()
 "mif";"agmip";"Item";"unit";"weight";"factor"
 "Nutrition|+|Calorie Supply (kcal/capita/day)";"CALO";"AGR";"kcal/capita/day";"NULL";1}
 
-\item{file}{name of the project specipic report, default=NULL means that the names of the header of the reporting is used}
+\item{file}{name of the output file, default=NULL returns the output as magclass object}
 
 \item{max_file_size}{maximum file size in MB; if size of file exceeds max_file_size reporting is split into multiple files}
 


### PR DESCRIPTION
In the current master, the object is always returned even if the output is written to a file.
In the new version, the output is only returned if file=NULL.