### PR TITLE
further harmonization among magpie_expand versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 5.3.1
+Version: 5.3.2
 Date: 2019-11-29
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
@@ -49,4 +49,4 @@ LazyData: true
 Encoding: UTF-8
 RoxygenNote: 7.0.1
 VignetteBuilder: knitr
-ValidationKey: 9679599
+ValidationKey: 9697828

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -79,6 +79,9 @@ magpie_expand_dim <- function(x,ref,dim=1) {
   
   m <- merge(dref,dx,sort=FALSE, suffixes=c("_ref","_x"), by=setdiff(intersect(names(dref), names(dx)),".line"))
   
+  # reorder m so that dref columns appear first
+  m <- m[union(names(dref)[1:(ncol(dref)-1)],names(m))]
+  
   tmpdim <- dim(x)
   tmpdim[dim] <- nrow(m)
   sizeCheck(tmpdim)

--- a/tests/testthat/test-magpie_expand.R
+++ b/tests/testthat/test-magpie_expand.R
@@ -3,8 +3,8 @@ library(testthat)
 context("Expansion Test")
 
 test_that("partial expansion", {
-  #skip("partial expansion not yet active by default")
-  options(magclass_expand_version=2.1)
+  skip("partial expansion not yet active by default")
+  #options(magclass_expand_version=2.1)
   a <- new.magpie(c("AFR.1","AFR.2","EUR.1"),fill = 1)
   b <- new.magpie(c("AFR","EUR"),fill = 1)
   expect_identical(magpie_expand(b,a),a)
@@ -25,5 +25,41 @@ test_that("partial expansion", {
   names(dimnames(g))[3] <- NA
   ff <- magpie_expand(f,g)
   expect_identical(ff,magpie_expand(g,ff))
+  
+  # subdimension order should remain unchanged if possible
+  names <- c("bla.value1","bla.value2")
+  h <- new.magpie("GLO",1900,names, fill=1)
+  i <- new.magpie("GLO",1900,c("value1","value2"), fill=1)
+  expect_identical(getItems(magpie_expand(i,h),3),names)
+  
+})
+
+test_that("expansion with unusual set names", {
+  skip("partial expansion with unusual set names not working with current default")
+  d <- new.magpie(c("AFR.BLUB.1","AFR.BLUB.2","EUR.BLUB.1","EUR.BLUB.2",
+                    "AFR.BLA.1","AFR.BLA.2","EUR.BLA.1","EUR.BLA.2"),fill = 1)
+  e <- new.magpie(c("BLA.AFR.A","BLA.EUR.A","BLUB.AFR.A","BLUB.EUR.A",
+                    "BLA.AFR.B","BLA.EUR.B","BLUB.AFR.B","BLUB.EUR.B"),fill = 1)
+  # test for cases with missing set names
+  names(dimnames(e)) <- NULL
+  ee <- magpie_expand(e,d)
+  expect_identical(ee,magpie_expand(d,ee))
+  
+  # test case with NA set name
+  f <- new.magpie("GLO",1900,"value", fill=1)
+  g <- new.magpie("GLO",1900,"blub", fill=1)
+  names(dimnames(g))[3] <- NA
+  ff <- magpie_expand(f,g)
+  expect_identical(ff,magpie_expand(g,ff))
+  
+})
+
+test_that("subdimension order", {
+  # subdimension order should remain unchanged if possible
+  names <- c("bla.value1","bla.value2")
+  h <- new.magpie("GLO",1900,names, fill=1)
+  i <- new.magpie("GLO",1900,c("value1","value2"), fill=1)
+  expect_identical(getItems(magpie_expand(i,h),3),names)
+  
 })
 


### PR DESCRIPTION
magpie_expand2.1 returns now objects with same dimension order as magpie_expand2