### PR TITLE
added temporal=2 to read.magpie function in case of netcdf files

### DIFF
--- a/R/read.magpie.R
+++ b/R/read.magpie.R
@@ -537,7 +537,7 @@ read.magpie <- function(file_name,file_folder="",file_type=NULL,as.array=FALSE,o
       }
       
       #convert array to magpie object
-      read.magpie <- clean_magpie(as.magpie(mag))
+      read.magpie <- clean_magpie(as.magpie(mag, temporal=2))
       getMetadata(read.magpie) <- metadata
       
     } else {


### PR DESCRIPTION
Small change in read.magpie.R for reading netcdf files.

I encountered the following issue: When reading .nc files from ISIMIP temporal dimension was not detected correctly. Issue is solved when adding temporal=2 to as.magpie(). 

Question: Can this mess up anything? I assumed not b/c years usually in 2nd dimension anyway. Is this correct?