### PR TITLE
added format in read/write.magpie: cs2b

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '94662082'
+ValidationKey: '94796800'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magclass: Data Class and Tools for Handling Spatial-Temporal Data",
-  "version": "5.11.3",
+  "version": "5.12.0",
   "description": "<p>Data class for increased interoperability working with spatial-\n    temporal data together with corresponding functions and methods (conversions,\n    basic calculations and basic data manipulation). The class distinguishes\n    between spatial, temporal and other dimensions to facilitate the development\n    and interoperability of tools build for it. Additional features are name-based\n    addressing of data and internal consistency checks (e.g. checking for the right\n    data order in calculations).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 5.11.3
-Date: 2020-09-09
+Version: 5.12.0
+Date: 2020-09-10
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),

--- a/R/read.magpie.R
+++ b/R/read.magpie.R
@@ -3,8 +3,8 @@
 #' Reads a MAgPIE-file and converts it to a 3D array of the structure
 #' (cells,years,datacolumn)
 #' 
-#' This function reads from 12 different MAgPIE file\_types. "rds" is
-#' a R-default format for storing R objects."cs2" is the new standard 
+#' This function reads from 13 different MAgPIE file\_types. "rds" is
+#' a R-default format for storing R objects."cs2" or "cs2b" is the new standard 
 #' format for cellular data with or without 
 #' header and the first columns (year,regiospatial) or only (regiospatial), 
 #' "csv" is the standard format for regional data with or without header 
@@ -27,9 +27,9 @@
 #' to file\_name and file\_folder)
 #' @param file_folder folder the file is located in (alternatively you can also
 #' specify the full path in file\_name - wildcards are supported)
-#' @param file_type format the data is stored in. Currently 12 formats are
+#' @param file_type format the data is stored in. Currently 13 formats are
 #' available: "rds" (recommended compressed format), 
-#' "cs2" (cellular standard MAgPIE format), "csv" (regional standard
+#' "cs2" & "cs2b" (cellular standard MAgPIE format), "csv" (regional standard
 #' MAgPIE format), "cs3" (multidimensional format compatible to GAMS), "cs4"
 #' (alternative multidimensional format compatible to GAMS, in contrast to cs3
 #' it can also handle sparse data), "csvr", "cs2r", "cs3r" and "cs4r" which are
@@ -112,7 +112,7 @@ read.magpie <- function(file_name,file_folder="",file_type=NULL,as.array=FALSE,o
   if(is.null(file_type)) {
     file_type <- tail(strsplit(file_name,'\\.')[[1]],1)
   }
-  if(!(file_type %in% c('rds','m','mz','csv','cs2','cs3','cs4','csvr','cs2r','cs3r','cs4r','put',"asc","nc","nc2"))) stop(paste("Unkown file type:",file_type))
+  if(!(file_type %in% c('rds','m','mz','csv','cs2','cs2b','cs3','cs4','csvr','cs2r','cs3r','cs4r','put',"asc","nc","nc2"))) stop(paste("Unkown file type:",file_type))
   
   .readComment <- function(file_name,comment.char="*",meta.char="#") {
     comment <- NULL
@@ -794,13 +794,13 @@ read.magpie <- function(file_name,file_folder="",file_type=NULL,as.array=FALSE,o
   }
   if(as.array){
     read.magpie <- as.magpie(read.magpie)
-    if(file_type %in% c('csv','cs2','cs3','cs4','csvr','cs2r','cs3r','cs4r') && withMetadata()){
+    if(file_type %in% c('csv','cs2','cs2b','cs3','cs4','csvr','cs2r','cs3r','cs4r') && withMetadata()){
       getMetadata(read.magpie) <- .readMetadata(file_name)
     }
     read.magpie <- as.array(read.magpie)[,,]
   } else {
     read.magpie <- as.magpie(read.magpie)
-    if(file_type %in% c('csv','cs2','cs3','cs4','csvr','cs2r','cs3r','cs4r') && withMetadata()){
+    if(file_type %in% c('csv','cs2','cs2b','cs3','cs4','csvr','cs2r','cs3r','cs4r') && withMetadata()){
       getMetadata(read.magpie) <- .readMetadata(file_name)
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **5.11.3**
+R package **magclass**, version **5.12.0**
 
 [![Travis build status](https://travis-ci.com/pik-piam/magclass.svg?branch=master)](https://travis-ci.com/pik-piam/magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/magclass)
 
@@ -54,9 +54,11 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K (2020). _magclass: Data Class and Tools for Handling
-Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version
-5.11.3, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K
+(2020). _magclass: Data Class and Tools for Handling Spatial-Temporal
+Data_. doi: 10.5281/zenodo.1158580 (URL:
+https://doi.org/10.5281/zenodo.1158580), R package version 5.12.0,
+<URL: https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +67,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens},
   year = {2020},
-  note = {R package version 5.11.3},
+  note = {R package version 5.12.0},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/man/read.magpie.Rd
+++ b/man/read.magpie.Rd
@@ -22,9 +22,9 @@ to file\_name and file\_folder)}
 \item{file_folder}{folder the file is located in (alternatively you can also
 specify the full path in file\_name - wildcards are supported)}
 
-\item{file_type}{format the data is stored in. Currently 12 formats are
+\item{file_type}{format the data is stored in. Currently 13 formats are
 available: "rds" (recommended compressed format), 
-"cs2" (cellular standard MAgPIE format), "csv" (regional standard
+"cs2" & "cs2b" (cellular standard MAgPIE format), "csv" (regional standard
 MAgPIE format), "cs3" (multidimensional format compatible to GAMS), "cs4"
 (alternative multidimensional format compatible to GAMS, in contrast to cs3
 it can also handle sparse data), "csvr", "cs2r", "cs3r" and "cs4r" which are
@@ -61,8 +61,8 @@ Reads a MAgPIE-file and converts it to a 3D array of the structure
 (cells,years,datacolumn)
 }
 \details{
-This function reads from 12 different MAgPIE file\_types. "rds" is
-a R-default format for storing R objects."cs2" is the new standard 
+This function reads from 13 different MAgPIE file\_types. "rds" is
+a R-default format for storing R objects."cs2" or "cs2b" is the new standard 
 format for cellular data with or without 
 header and the first columns (year,regiospatial) or only (regiospatial), 
 "csv" is the standard format for regional data with or without header 

--- a/man/write.magpie.Rd
+++ b/man/write.magpie.Rd
@@ -29,11 +29,11 @@ to file\_name and file\_folder)}
 \item{file_folder}{folder the file should be written to (alternatively you
 can also specify the full path in file\_name - wildcards are supported)}
 
-\item{file_type}{Format the data should be stored as. Currently 12 formats
-are available: "rds" (default R-data format), 
-cs2" (cellular standard MAgPIE format), "csv" (regional standard MAgPIE 
-format), "cs3" (Format for multidimensional MAgPIE data,
-compatible to GAMS), "cs4" (alternative multidimensional format compatible
+\item{file_type}{Format the data should be stored as. Currently 13 formats
+are available: "rds" (default R-data format), "cs2" (cellular standard 
+MAgPIE format), "cs2b" (cellular standard MAgPIE format with suppressed header ndata=1),
+"csv" (regional standard MAgPIE format), "cs3" (Format for multidimensional MAgPIE 
+data, compatible to GAMS), "cs4" (alternative multidimensional format compatible
 to GAMS, in contrast to cs3 it can also handle sparse data), "csvr", "cs2r",
 "cs3r" and "cs4r" which are the same formats as the previous mentioned ones
 with the only difference that they have a REMIND compatible format, "m"
@@ -81,13 +81,15 @@ Writes a MAgPIE-3D-array (cells,years,datacolumn) to a file in one of three
 MAgPIE formats (standard, "magpie", "magpie zipped")
 }
 \details{
-This function can write 12 different MAgPIE file\_types. "cs2" is the new
+This function can write 13 different MAgPIE file\_types. "cs2" is the new
 standard format for cellular data with or without header and the first
-columns (year,regiospatial) or only (regiospatial), "csv" is the standard
-format for regional data with or without header and the first columns
-(year,region,cellnumber) or only (region,cellnumber), "cs3" is another csv
-format which is specifically designed for multidimensional data for usage in
-GAMS.  All these variants are written without further specification. "rds" is
+columns (year,regiospatial) or only (regiospatial), "cs2b" is identical to
+"cs2" except that it will suppress the data name if it has only 1 element
+in the data dimension. "csv" is the standard format for regional 
+data with or without header and the first columns (year,region,cellnumber) 
+or only (region,cellnumber), "cs3" is another csv format which is 
+specifically designed for multidimensional data for usage in GAMS.  
+All these variants are written without further specification. "rds" is
 a R-default format for storing R objects.
 "magpie" (.m) and "magpie zipped" (.mz) are new formats developed to allow a
 less storage intensive management of MAgPIE-data. The only difference


### PR DESCRIPTION
added cs2b format to read/write.magpie which is a small modification of cs2 (it ignores the data name for objects with a single data column. This is in some cases required for further processing in GAMS)