### PR TITLE
as.data.frame only converts years to int if possible

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '98403740'
+ValidationKey: '98582920'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/test-buildlibrary.yaml
+++ b/.github/workflows/test-buildlibrary.yaml
@@ -13,8 +13,6 @@ name: check
 jobs:
   check:
     runs-on: ubuntu-20.04
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -52,11 +50,15 @@ jobs:
             BiocManager::install(missing$package)
           }
           remotes::install_deps(dependencies = TRUE, repos=repos)
-          remotes::install_cran(c("covr","lucode2"), repos=repos)
+          remotes::install_cran(c("devtools","covr","lucode2"), repos=repos)
+        shell: Rscript {0}
+        
+      - name: Run tests
+        run: devtools::test(stop_on_failure = TRUE)
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov()
+        run: covr::codecov(quiet = FALSE)
         shell: Rscript {0}
         
       - name: Validation key 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magclass: Data Class and Tools for Handling Spatial-Temporal Data",
-  "version": "5.25.1",
+  "version": "5.26.0",
   "description": "<p>Data class for increased interoperability working with spatial-\n    temporal data together with corresponding functions and methods (conversions,\n    basic calculations and basic data manipulation). The class distinguishes\n    between spatial, temporal and other dimensions to facilitate the development\n    and interoperability of tools build for it. Additional features are name-based\n    addressing of data and internal consistency checks (e.g. checking for the right\n    data order in calculations).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 5.25.1
-Date: 2021-04-23
+Version: 5.26.0
+Date: 2021-04-25
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),

--- a/R/as.data.frame.R
+++ b/R/as.data.frame.R
@@ -33,7 +33,12 @@ setMethod("as.data.frame",
   function(x,rev=1) 
   {
     if(rev==1) {
-      dimnames(x)[[2]] <- getYears(x,as.integer=TRUE)
+      yearsAsIntegers <- suppressWarnings(getYears(x,as.integer=TRUE))
+      if(any(is.na(getYears(x)) != is.na(yearsAsIntegers))) {
+        dimnames(x)[[2]] <- getYears(x)
+      } else {
+        dimnames(x)[[2]] <- yearsAsIntegers
+      }
       if(is.null(dimnames(x)[[2]])) dimnames(x)[[2]] <- 0
       if(is.null(dimnames(x)[[3]])) dimnames(x)[[3]] <- "NA"
       if(any(dim(x)==0)) {

--- a/R/getYears.R
+++ b/R/getYears.R
@@ -29,7 +29,7 @@
 #' @export
 getYears <- function(x,as.integer=FALSE) {
   if(as.integer) {
-    return(as.integer(substring(dimnames(x)[[2]],2)))  
+    return(as.integer(sub("^y", "", dimnames(x)[[2]])))
   } else {
     return(dimnames(x)[[2]])
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **5.25.1**
+R package **magclass**, version **5.26.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580)  [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/magclass)
 
@@ -54,9 +54,10 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2021). _magclass: Data Class and Tools for
-Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package
-version 5.25.1, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2021).
+_magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:
+10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package
+version 5.26.0, <URL: https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +66,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip},
   year = {2021},
-  note = {R package version 5.25.1},
+  note = {R package version 5.26.0},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/tests/testthat/test-as.data.frame.R
+++ b/tests/testthat/test-as.data.frame.R
@@ -1,0 +1,41 @@
+test_that("years is not converted if conversion to int fails", {
+  df <- as.data.frame(new.magpie("AFR.1", "2000-02-02", "test", 123))
+  expected <- data.frame(Cell = 1,
+                         Region = "AFR",
+                         Year = factor("2000-02-02"),
+                         Data1 = factor("test"),
+                         Value = 123)
+  expect_equal(df, expected)
+
+  df <- as.data.frame(new.magpie("AFR.1", "some text", "test", 123))
+  expected <- data.frame(Cell = 1,
+                         Region = "AFR",
+                         Year = factor("some text"),
+                         Data1 = factor("test"),
+                         Value = 123)
+  expect_equal(df, expected)
+
+  df <- as.data.frame(new.magpie("AFR.1", "2000", "test", 123))
+  expected <- data.frame(Cell = 1,
+                         Region = "AFR",
+                         Year = factor(2000),
+                         Data1 = factor("test"),
+                         Value = 123)
+  expect_equal(df, expected)
+
+  df <- as.data.frame(new.magpie("AFR.1", "y2000", "test", 123))
+  expected <- data.frame(Cell = 1,
+                         Region = "AFR",
+                         Year = factor(2000),
+                         Data1 = factor("test"),
+                         Value = 123)
+  expect_equal(df, expected)
+
+  df <- as.data.frame(new.magpie("AFR.1","yy2000", "test", 123))
+  expected <- data.frame(Cell = 1,
+                         Region = "AFR",
+                         Year = factor("yy2000"),
+                         Data1 = factor("test"),
+                         Value = 123)
+  expect_equal(df, expected)
+})


### PR DESCRIPTION
Before these changes, as.data.frame from a magpie object would replace entries in the "years" column in a format like "2000-02-02" with NAs. Also, the format "y2000" was expected, so the first character was always discarded: "y2000" -> 2000, but "2123" -> 123. Now both formats are correctly converted to int.