### PR TITLE
Parentheses in units

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '11824640'
+ValidationKey: '12021660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magclass: Data Class and Tools for Handling Spatial-Temporal Data",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "<p>Data class for increased interoperability working with spatial-\n    temporal data together with corresponding functions and methods (conversions,\n    basic calculations and basic data manipulation). The class distinguishes\n    between spatial, temporal and other dimensions to facilitate the development\n    and interoperability of tools build for it. Additional features are name-based\n    addressing of data and internal consistency checks (e.g. checking for the right\n    data order in calculations).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.2.0
-Date: 2022-03-21
+Version: 6.3.0
+Date: 2022-03-31
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),

--- a/R/write.report.R
+++ b/R/write.report.R
@@ -168,15 +168,35 @@ prepareData <- function(x, model = NULL, scenario = NULL, unit = NULL, skipempty
 }
 
 unitsplit <- function(x, col) {
-  # group 1: greedy everything
-  # separator: a space
-  # group 2: unit, surrounded by () which are not part of the group
-  # the unit may not contain "|"
-  # the end of the string
-  pattern <- "^(.*) \\(([^|]*)\\)$"
-  varName <- sub(pattern, "\\1", x[[col]])
-  unit <- sub(pattern, "\\2", x[[col]])
-  unit[grep(pattern, x[[col]], invert = TRUE)] <- "N/A"
+  # structure of this regex (flavor: PCRE2):
+  # '^' start of the string
+  # '(?P<varname>…)' a named capture group for the varname. It contains:
+  #   '.*' greedy everything
+  # ' ' separator: a space
+  # '(?P<recurse>…)' a named capture group for recursion to match balanced parentheses in the unit. It contains:
+  #   '\\(' a literal opening parenthesis
+  #   '(?P<unit>…)' a named capture group for the unit. It contains:
+  #      '(?>…)*' an atomic non-capturing group which is repeated zero or more times. It contains:
+  #          `[^()|]` any character which is neither a parenthesis or the pipe symbol
+  #          `|` or
+  #          `(?P>recurse)` a match for the named capture group "recurse".
+  #          As the named capture group "recurse" contains exactly one literal opening and closing parenthesis, this
+  #          recursion makes sure that parentheses in the unit are always balanced - if a parenthesis needs to be
+  #          matched, we have to repeat the whole "recurse" capture group, and therefore, we need exactly one literal
+  #          opening and closing parenthesis (or another recursion).
+  #   '\\)' a literal closing parenthesis
+  # '$' end of the string
+  # If you have to understand the regex, I can warmly recommend putting it into https://regex101.com/ or a similar
+  # service. Just replace all '\\' by '\', double backslashes are an R thing.
+  pattern <- "^(?P<varname>.*) (?P<recurse>\\((?P<unit>(?>[^()|]|(?P>recurse))*)\\))$"
+  # Even though we use named capture groups in the pattern, we can't use names in the replacement, because sub() only
+  # supports numbered replacements. \\1 is the named capture group "varname", \\3 is the named capture group "unit".
+  # Note that if the pattern does not match (e.g. because the value in question does not contain a unit), sub will not
+  # replace anything, effectively passing everything through unchanged to varName and unit. That's correct for varName,
+  # but for the unit, we have to overwrite non-matches with "N/A".
+  varName <- sub(pattern, "\\1", x[[col]], perl=TRUE)
+  unit <- sub(pattern, "\\3", x[[col]], perl=TRUE)
+  unit[grep(pattern, x[[col]], invert = TRUE, perl=TRUE)] <- "N/A"
   tmp <- data.frame(varName, unit)
   names(tmp) <- c(names(x)[col], "unit")
   x <- cbind(tmp, x[setdiff(seq_len(ncol(x)), col)])

--- a/R/write.report.R
+++ b/R/write.report.R
@@ -194,9 +194,9 @@ unitsplit <- function(x, col) {
   # Note that if the pattern does not match (e.g. because the value in question does not contain a unit), sub will not
   # replace anything, effectively passing everything through unchanged to varName and unit. That's correct for varName,
   # but for the unit, we have to overwrite non-matches with "N/A".
-  varName <- sub(pattern, "\\1", x[[col]], perl=TRUE)
-  unit <- sub(pattern, "\\3", x[[col]], perl=TRUE)
-  unit[grep(pattern, x[[col]], invert = TRUE, perl=TRUE)] <- "N/A"
+  varName <- sub(pattern, "\\1", x[[col]], perl = TRUE)
+  unit <- sub(pattern, "\\3", x[[col]], perl = TRUE)
+  unit[grep(pattern, x[[col]], invert = TRUE, perl = TRUE)] <- "N/A"
   tmp <- data.frame(varName, unit)
   names(tmp) <- c(names(x)[col], "unit")
   x <- cbind(tmp, x[setdiff(seq_len(ncol(x)), col)])

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.2.0**
+R package **magclass**, version **6.3.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2022). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.2.0, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2022). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.3.0, <URL: https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip},
   year = {2022},
-  note = {R package version 6.2.0},
+  note = {R package version 6.3.0},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/magclass.Rproj
+++ b/magclass.Rproj
@@ -17,3 +17,5 @@ PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace,vignette
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes

--- a/tests/testthat/test-readwritereport.R
+++ b/tests/testthat/test-readwritereport.R
@@ -178,9 +178,9 @@ test_that("unitsplit handles all cases", {
   expect_identical(wrapper("Price|Agriculture (with cows)|Corn|Index (Index (2020 = 1))"),
                    c("Price|Agriculture (with cows)|Corn|Index", "Index (2020 = 1)"))
   expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020) ((1 + 2) / (6 - 3))"),
-                   c("Price|Agriculture|Corn|Index (based on 2020) ", "(1 + 2) / (6 - 3)"))
+                   c("Price|Agriculture|Corn|Index (based on 2020)", "(1 + 2) / (6 - 3)"))
   expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020 (-;) ((1 + 2) / (6 - 3))"),
-                   c("Price|Agriculture|Corn|Index (based on 2020 (-;) ", "(1 + 2) / (6 - 3)"))
+                   c("Price|Agriculture|Corn|Index (based on 2020 (-;)", "(1 + 2) / (6 - 3)"))
   expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020 :-)) ((1 + 2) / (6 - 3))"),
-                   c("Price|Agriculture|Corn|Index (based on 2020 :-)) ", "(1 + 2) / (6 - 3)"))
+                   c("Price|Agriculture|Corn|Index (based on 2020 :-))", "(1 + 2) / (6 - 3)"))
 })

--- a/tests/testthat/test-readwritereport.R
+++ b/tests/testthat/test-readwritereport.R
@@ -173,4 +173,14 @@ test_that("unitsplit handles all cases", {
                    c("carpet (the good one)|length (US)", "inch"))
   expect_identical(wrapper("carpet (the good one)|make (as given) ()"),
                    c("carpet (the good one)|make (as given)", ""))
+  expect_identical(wrapper("Price|Agriculture|Corn|Index (Index (2020 = 1))"),
+                   c("Price|Agriculture|Corn|Index", "Index (2020 = 1)"))
+  expect_identical(wrapper("Price|Agriculture (with cows)|Corn|Index (Index (2020 = 1))"),
+                   c("Price|Agriculture (with cows)|Corn|Index", "Index (2020 = 1)"))
+  expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020) ((1 + 2) / (6 - 3))"),
+                   c("Price|Agriculture|Corn|Index (based on 2020) ", "(1 + 2) / (6 - 3)"))
+  expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020 (-;) ((1 + 2) / (6 - 3))"),
+                   c("Price|Agriculture|Corn|Index (based on 2020 (-;) ", "(1 + 2) / (6 - 3)"))
+  expect_identical(wrapper("Price|Agriculture|Corn|Index (based on 2020 :-)) ((1 + 2) / (6 - 3))"),
+                   c("Price|Agriculture|Corn|Index (based on 2020 :-)) ", "(1 + 2) / (6 - 3)"))
 })


### PR DESCRIPTION
After we added support for parentheses in variable names in `write.report()`, it quickly became apparent that people also want to put parentheses into units. Since the most general case with parentheses in the variable name and the unit is actually not properly defined, we can only support *balanced* parentheses in the unit, i.e. as many opening as closing parentheses.

To support this, I had to resort to perl-compatible regular expressions with [subroutines](https://www.regular-expressions.info/subroutine.html). I added a lot of comments in the hope that whoever has to touch this next has a chance to understand the regex.