### PR TITLE
Bugfixes in write.magpie and write.report

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,6 @@ cran-comments.md
 ^\.pre-commit-config\.yaml$
 ^workflow$
 ^\.idea$
+^.lintr$
+^tests/.lintr$
+^vignettes/.lintr$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '12257280'
+ValidationKey: '12290534'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -56,6 +56,18 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Cache R libraries
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/lib/R/
+          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: |
+            ${{ runner.os }}-usr-local-lib-R-
+
+      - name: Restore R library permissions
+        run: |
+          sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
+
       - name: Install dependencies
         run: |
           ./run.sh install_aptget libhdf5-dev

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,2 @@
+linters: lucode2::lintrRules()
+encoding: "UTF-8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magclass: Data Class and Tools for Handling Spatial-Temporal Data",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "<p>Data class for increased interoperability working with spatial-\n    temporal data together with corresponding functions and methods (conversions,\n    basic calculations and basic data manipulation). The class distinguishes\n    between spatial, temporal and other dimensions to facilitate the development\n    and interoperability of tools build for it. Additional features are name-based\n    addressing of data and internal consistency checks (e.g. checking for the right\n    data order in calculations).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: magclass
 Type: Package
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.4.0
-Date: 2022-06-09
+Version: 6.4.1
+Date: 2022-07-01
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Markus", "Bonsch", role = "aut"),

--- a/R/write.magpie.R
+++ b/R/write.magpie.R
@@ -102,14 +102,14 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
     mode <- as.character(777 - as.integer(as.character(umask)))
   }
   if (is.null(x)) x <- as.magpie(numeric(0))
-  if (is.magpie(x) || class(x) == "RasterBrick") {
+  if (is.magpie(x) || inherits(x, "RasterBrick")) {
     years <- !(is.null(dimnames(x)[[2]]))
 
     # if file-type is not mentioned file-ending is used as file-type
     if (is.null(file_type)) {
       file_type <- tail(strsplit(file_name, "\\.")[[1]], 1) # nolint
     }
-    if (class(x) == "RasterBrick" && !(file_type %in% c("nc", "asc", "grd", "tif"))) {
+    if (inherits(x, "RasterBrick") && !(file_type %in% c("nc", "asc", "grd", "tif"))) {
       stop("RasterBrick format is only allowed for file types: nc, asc, grd and tif")
     }
     if (!file_folder == "") {

--- a/R/write.magpie.R
+++ b/R/write.magpie.R
@@ -119,8 +119,9 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
     }
 
     # look for comment/additional information
-    if (is.null(comment) & !is.null(attr(x, "comment"))) comment <- attr(x, "comment")
+    if (is.null(comment) && !is.null(attr(x, "comment"))) comment <- attr(x, "comment")
     if (is.null(comment)) comment <- ""
+    comment <- unlist(strsplit(comment, "\n"))
 
     # expand wildcards
     filePath <- file.path(Sys.glob(dirname(filePath)), basename(filePath))
@@ -129,7 +130,7 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
       warning("file name is ambiguous, only first alternative is used!")
     }
 
-    if (append & file.exists(filePath)) {
+    if (append && file.exists(filePath)) {
       x2 <- read.magpie(filePath)
       x <- mbind(x2, x)
     }
@@ -254,7 +255,7 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
       ncdf4::nc_close(nc)
     } else if (file_type == "rds") {
       saveRDS(object = x, file = filePath, ...)
-    } else if (file_type == "cs3" | file_type == "cs3r") {
+    } else if (file_type == "cs3" || file_type == "cs3r") {
       if (file_type == "cs3r") dimnames(x)[[2]] <- sub("y", "", dimnames(x)[[2]])
       if (dim(x)[3] != prod(sapply(getItems(x, dim = 3, split = TRUE), length))) { # nolint
         stop("Input data seems to be sparse but ", file_type, " does not support sparse data. Please use ",
@@ -288,7 +289,7 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
       write.csv(x, file = zz, quote = FALSE, row.names = FALSE)
       close(zz)
       Sys.chmod(filePath, mode)
-    } else if (file_type == "cs4" | file_type == "cs4r") {
+    } else if (file_type == "cs4" || file_type == "cs4r") {
       printCells <- nregions(x) < ncells(x)
       printRegions <- (!is.null(getItems(x, dim = 1.1)) && getItems(x, dim = 1.1)[1] != "GLO")
       printData <- ((ndata(x) > 1) | !is.null(getNames(x)))
@@ -318,8 +319,8 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
       if (file_type == "cs2b" && ndata(x) == 1) getNames(x) <- NULL
 
       # non-cellular data
-      if (!printCells & (!printData | !years | !printRegions)) {
-        if (file_type == "csvr" | file_type == "cs2r") dimnames(x)[[2]] <- sub("y", "", dimnames(x)[[2]])
+      if (!printCells && (!printData || !years || !printRegions)) {
+        if (file_type == "csvr" || file_type == "cs2r") dimnames(x)[[2]] <- sub("y", "", dimnames(x)[[2]])
         if (!printData) {
           output <-  array(x, dim = dim(x)[1:2], dimnames = list(dimnames(x)[[1]], dimnames(x)[[2]]))
           output <- aperm(output)
@@ -339,7 +340,7 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
           output <-  array(x, dim = dim(x)[c(1, 3)], dimnames = list(dimnames(x)[[1]], dimnames(x)[[3]]))
           header <- !is.null(dimnames(output)[[2]])
           if (printRegions) output <- cbind(substring(dimnames(x)[[1]], 1, 3), output)
-          if (header & !printRegions) {
+          if (header && !printRegions) {
             output <- t(output)
             header <- FALSE
             output <- cbind(dimnames(x)[[3]], output)
@@ -350,14 +351,14 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
           output <- cbind(dimnames(x)[[2]], output)
           dimnames(output)[[2]][1] <- "dummy"
         }
-        if (header & printRegions) dimnames(output)[[2]][1] <- "dummy"
+        if (header && printRegions) dimnames(output)[[2]][1] <- "dummy"
         zz <- file(filePath, open = "w")
         if (any(comment != "")) writeLines(paste(comment.char, comment, sep = ""), zz)
         write.table(output, zz, sep = ",", col.names = header, row.names = FALSE, quote = FALSE)
         close(zz)
         Sys.chmod(filePath, mode)
       } else {
-        if (file_type == "csvr" | file_type == "cs2r") dimnames(x)[[2]] <- sub("y", "", dimnames(x)[[2]])
+        if (file_type == "csvr" || file_type == "cs2r") dimnames(x)[[2]] <- sub("y", "", dimnames(x)[[2]])
         if (file_type %in% c("cs2", "cs2b", "cs2r")) printRegions <- FALSE
         output <- array(NA, c(dim(x)[1] * dim(x)[2], dim(x)[3] + printRegions + printCells + years))
         output[, (1 + printRegions + printCells + years):dim(output)[2]] <- as.vector(as.matrix(x))
@@ -371,7 +372,7 @@ write.magpie <- function(x, file_name, file_folder = "", file_type = NULL, appen
           if (file_type %in% c("cs2", "cs2b", "cs2r")) {
             output[, 1 + printRegions + years] <- rep(gsub(".", "_", dimnames(x)[[1]], fixed = TRUE), dim(x)[2])
           } else {
-            output[, 1 + printRegions + years] <- rep(1:dim(x)[1], dim(x)[2])
+            output[, 1 + printRegions + years] <- rep(seq_len(dim(x)[1]), dim(x)[2])
           }
         }
         if (!is.null(dimnames(x)[[3]])) {

--- a/R/write.report.R
+++ b/R/write.report.R
@@ -28,7 +28,7 @@
 #' write.report(maxample("pop"))
 #' @importFrom utils write.table
 #' @export
-write.report <- function(x, file = NULL, model = NULL, scenario = NULL, unit = NULL, ndigit = 4,
+write.report <- function(x, file = NULL, model = NULL, scenario = NULL, unit = NULL, ndigit = 4, # nolint
                          append = FALSE, skipempty = TRUE, extracols = NULL) {
 
   scenarioCall <- scenario
@@ -197,7 +197,7 @@ unitsplit <- function(x, col) {
   varName <- sub(pattern, "\\1", x[[col]], perl = TRUE)
   unit <- sub(pattern, "\\3", x[[col]], perl = TRUE)
   unit[grep(pattern, x[[col]], invert = TRUE, perl = TRUE)] <- "N/A"
-  tmp <- data.frame(varName, unit)
+  tmp <- data.frame(varName, unit, stringsAsFactors = FALSE)
   names(tmp) <- c(names(x)[col], "unit")
   x <- cbind(tmp, x[setdiff(seq_len(ncol(x)), col)])
   return(x)

--- a/R/write.report.R
+++ b/R/write.report.R
@@ -119,7 +119,7 @@ prepareData <- function(x, model = NULL, scenario = NULL, unit = NULL, skipempty
 
   for (i in seq_along(x)) {
     if (tolower(names(x)[i]) %in% c("scenario", "model", "region")) next
-    if (class(x[[i]]) != "character") next
+    if (!inherits(x[[i]], "character")) next
     if (!any(grepl(" \\(.*\\)$", x[[i]]))) next
     x <- unitsplit(x, i)
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.4.0**
+R package **magclass**, version **6.4.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -55,7 +55,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2022). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.4.0, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2022). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.4.1, <URL: https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -64,7 +64,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip},
   year = {2022},
-  note = {R package version 6.4.0},
+  note = {R package version 6.4.1},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/tests/.lintr
+++ b/tests/.lintr
@@ -1,0 +1,2 @@
+linters: lucode2::lintrRules(allowUndesirable = TRUE)
+encoding: "UTF-8"

--- a/tests/testthat/test-readwritereport.R
+++ b/tests/testthat/test-readwritereport.R
@@ -1,5 +1,5 @@
 p <- maxample("pop")
-attr(p, "Metadata") <- NULL
+attr(p, "Metadata") <- NULL # nolint
 
 test_that("read/write report works", {
   ref <- structure(list(Model = "N/A", Scenario = "N/A", Region = "World", Variable = "1",
@@ -109,7 +109,7 @@ test_that("read/write report works with braces", {
                     fill = 0)
   foo["DEU", 2020, "Emissions|CO2|Energy|Demand|Transportation (w/ bunkers) (Mt CO2/yr)"] <- 10
   expect_silent(write.report(foo, f))
-  df <- read.csv(f, sep = ";")
+  df <- read.csv(f, sep = ";", stringsAsFactors = FALSE)
   expect_identical(df$Unit, "Mt CO2/yr")
 })
 
@@ -121,7 +121,8 @@ test_that("simple unitsplit works", {
     Data = c("floor covering|textile|carpet|red|length (m)",
              "floor covering|textile|carpet|red|length - for our american friends (inch)",
              "floor covering|textile|carpet|red|length (cm)"),
-    check.names = FALSE
+    check.names = FALSE,
+    stringsAsFactors = FALSE
   )
   expected <- data.frame(
     Data = c("floor covering|textile|carpet|red|length",
@@ -131,7 +132,8 @@ test_that("simple unitsplit works", {
     Model = c("REMIND", "REMIND", "REMIND"),
     Scenario = c("everything nice", "everything awful", "middle of the road"),
     Region = c("GLO", "GLO", "GLO"),
-    check.names = FALSE
+    check.names = FALSE,
+    stringsAsFactors = FALSE
   )
   expect_identical(unitsplit(df, 4), expected)
 })
@@ -144,7 +146,8 @@ test_that("unitsplit works with braces", {
     Data = c("floor covering|textile|carpet|red|length (m)",
              "floor covering|textile|carpet|red|length (for our american friends) (inch)",
              "floor covering|textile|carpet|red|length (cm)"),
-    check.names = FALSE
+    check.names = FALSE,
+    stringsAsFactors = FALSE
   )
   expected <- data.frame(
     Data = c("floor covering|textile|carpet|red|length",
@@ -154,14 +157,15 @@ test_that("unitsplit works with braces", {
     Model = c("REMIND", "REMIND", "REMIND"),
     Scenario = c("everything nice", "everything awful", "middle of the road"),
     Region = c("GLO", "GLO", "GLO"),
-    check.names = FALSE
+    check.names = FALSE,
+    stringsAsFactors = FALSE
   )
   expect_identical(unitsplit(df, 4), expected)
 })
 
 test_that("unitsplit handles all cases", {
   wrapper <- function(inputstr) {
-    df <- data.frame(c(inputstr))
+    df <- data.frame(c(inputstr), stringsAsFactors = FALSE)
     splitted <- unitsplit(df, 1)
     return(c(splitted[[1]], splitted[[2]]))
   }

--- a/vignettes/.lintr
+++ b/vignettes/.lintr
@@ -1,0 +1,2 @@
+linters: lucode2::lintrRules(allowUndesirable = TRUE)
+encoding: "UTF-8"


### PR DESCRIPTION
- fixed a bug in write.magpie in which the comment character was missing at the beginning of comments in csv files if line breaks were being used in the comment

- fixed another bug in which magclass:::unitsplit was working incorrectly for R version < 4.0 (which had a different default setting for stringsAsFactors in various functions)