### PR TITLE
have sizeCheck() report dimensions when throwing an error

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '12995257'
+ValidationKey: '13174320'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "magclass: Data Class and Tools for Handling Spatial-Temporal Data",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "description": "<p>Data class for increased interoperability working with\n    spatial-temporal data together with corresponding functions and\n    methods (conversions, basic calculations and basic data manipulation).\n    The class distinguishes between spatial, temporal and other dimensions\n    to facilitate the development and interoperability of tools build for\n    it. Additional features are name-based addressing of data and internal\n    consistency checks (e.g. checking for the right data order in\n    calculations).<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.7.1
-Date: 2023-01-10
+Version: 6.8.0
+Date: 2023-01-17
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),

--- a/R/sizeCheck.R
+++ b/R/sizeCheck.R
@@ -8,16 +8,26 @@
 #' @param dim dimensions of the current object as returned by function \code{dim}
 #' @author Jan Philipp Dietrich
 #' @examples
-#'
 #' pop <- maxample("pop")
 #' magclass:::sizeCheck(dim(pop))
+#'
+#' \dontrun{
+#' magclass:::sizeCheck(c(6765L, 10946L, 17711L))
+#' }
 sizeCheck <- function(dim) {
+  if (!is.vector(dim, "integer")) {
+    stop("Numeric vector of dimension sizes expected.")
+  }
+
   if (is.null(getOption("magclass_sizeLimit"))) options(magclass_sizeLimit = 10^9) #nolint
   # estimate new object size and check against size limit
   if (getOption("magclass_sizeLimit") > 0) {
     size <- prod(dim)
     if (size > getOption("magclass_sizeLimit")) {
-        stop("magclass object size limit reached! getOption(\"magclass_sizeLimit\")=", getOption("magclass_sizeLimit"))
+      stop("magclass object size ",
+           "(", paste(dim, collapse = " x "), " = ", size, ") ",
+           "exceeds limit (getOption(\"magclass_sizeLimit\") = ",
+           getOption("magclass_sizeLimit"), ").")
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.7.1**
+R package **magclass**, version **6.8.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2023). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.7.1, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2023). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.8.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +65,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip},
   year = {2023},
-  note = {R package version 6.7.1},
+  note = {R package version 6.8.0},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/tests/testthat/test-various.R
+++ b/tests/testthat/test-various.R
@@ -120,9 +120,19 @@ test_that("getYear works", {
 
 test_that("sizeCheck works", {
   limit <- getOption("magclass_sizeLimit")
+  withr::defer(options(magclass_sizeLimit = limit))
+
+  # passing magpie objects instead of magpie object dimensions
+  expect_error(magclass:::sizeCheck(p),
+               "Numeric vector of dimension sizes expected.")
+
+  # passing magpie object dimensions
+  expect_null(magclass:::sizeCheck(dim(p)))
+
+  # passing too large magpie object dimensions
   options(magclass_sizeLimit = 1)
-  on.exit(options(magclass_sizeLimit = limit))
-  expect_error(magclass:::sizeCheck(p), "object size limit reached")
+  expect_error(magclass:::sizeCheck(dim(p)),
+               "magclass object size .* exceeds limit")
 })
 
 test_that("log methods work", {


### PR DESCRIPTION
We had the problem lately that REMIND preprocessing OOMclassed on some too-large magpie object.  This addition would give us a hint if it was just some incremental change (n more scenarios) or some exponential increase in the "names" , like combining incompatible dimensions and getting all the combinations.

Output looks like:
```
Error in magclass:::sizeCheck(c(6765L, 10946L, 17711L)) : 
  magclass object size (6765 x 10946 x 17711 = 1311494059590) exceeds limit (getOption("magclass_sizeLimit") = 1e+09).
```

Also fixes a false-negative test, that would fail because a magpie object got passed, but not the dimension of the magpie object.