### PR TITLE
add optional check for duplication in third dimension to mbind()

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '13476573'
+ValidationKey: '119126900'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 6.9.1
-date-released: '2023-05-26'
+version: 6.10.0
+date-released: '2023-06-21'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.9.1
-Date: 2023-05-26
+Version: 6.10.0
+Date: 2023-06-21
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),

--- a/R/mbind.R
+++ b/R/mbind.R
@@ -28,7 +28,7 @@
 
 mbind <- function(...) { #nolint
   inputs <- list(...)
-  if (length(inputs) == 1 & is.list(inputs[[1]])) inputs <- inputs[[1]]
+  if (length(inputs) == 1 && is.list(inputs[[1]])) inputs <- inputs[[1]]
   # Remove NULL elements from list
   for (i in rev(seq_along(inputs))) {
     if (is.null(inputs[[i]])) {
@@ -63,9 +63,9 @@ mbind <- function(...) { #nolint
     years <- c(years, getYears(inputs[[i]]))
     elems <- c(elems, getNames(inputs[[i]]))
     cells <- c(cells, getCells(inputs[[i]]))
-    if (!diffspat & ncells(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][getCells(inputs[[1]]), , ]
-    if (!difftemp & nyears(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][, getYears(inputs[[1]]), ]
-    if (!diffdata &  ndata(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][, , getNames(inputs[[1]])]
+    if (!diffspat && ncells(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][getCells(inputs[[1]]), , ]
+    if (!difftemp && nyears(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][, getYears(inputs[[1]]), ]
+    if (!diffdata &&  ndata(inputs[[1]]) > 1) inputs[[i]] <- inputs[[i]][, , getNames(inputs[[1]])]
   }
 
   if (!(length(grep(".", cells, fixed = TRUE)) %in% c(0, length(cells)))) {
@@ -73,9 +73,9 @@ mbind <- function(...) { #nolint
          " data objects! Cannot handle this case!")
   }
 
-  if (diffspat & difftemp) stop("Cannot handle objects! Spatial as well as temporal dimensions differ!")
-  if (difftemp & diffdata) stop("Cannot handle objects! Data as well as temporal dimensions differ!")
-  if (diffdata & diffspat) stop("Cannot handle objects! Data as well as spatial dimensions differ!")
+  if (diffspat && difftemp) stop("Cannot handle objects! Spatial as well as temporal dimensions differ!")
+  if (difftemp && diffdata) stop("Cannot handle objects! Data as well as temporal dimensions differ!")
+  if (diffdata && diffspat) stop("Cannot handle objects! Data as well as spatial dimensions differ!")
   if (difftemp) {
     if (length(years) != length(unique(years))) stop("Some years occur more than once!",
                                                      " Cannot handle this case!")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.9.1**
+R package **magclass**, version **6.10.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2023). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.9.1, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D (2023). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.10.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +65,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip},
   year = {2023},
-  note = {R package version 6.9.1},
+  note = {R package version 6.10.0},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }

--- a/tests/testthat/test-mbind.R
+++ b/tests/testthat/test-mbind.R
@@ -1,7 +1,7 @@
 
 a  <- maxample("animal")
 p  <- maxample("pop")
-attr(p, "Metadata") <- NULL
+attr(p, "Metadata") <- NULL # nolint: object_name_linter # nolint: linter_name_linter
 
 test_that("mbind works", {
   expect_identical(mbind(p, p), p[, , c(1:2, 1:2)])


### PR DESCRIPTION
I had a hard time tracking down where duplicated dimnames where introduced that `.dimextract()` complained about, so I generalised the solution.

> `mbind()` checks the R option `MAGPIE_MBIND_DUPLICATES`, which should have the format `'<reaction>_<filter>'`. If <reaction> is either `'warning'` or `'stop'`, `mbind()` will raise a warning or an error when it introduces duplicates in the third dimension of the resulting magpie object. If <filter> is set to `'remove-plus'`, it will check for duplicates disregarding `'|+'` components in the names (as are used for REMIND output variables). This is intended for debugging purposes. See also the examples.

> ```
> ## Not run: 
> options(MAGPIE_MBIND_DUPLICATES = "warning_remove-plus")
> mbind(new.magpie(names = 'foo|bar'), new.magpie(names = 'foo|+|bar'))
> 
> ## End(Not run)
> ```