### PR TITLE
more memory efficient writeNC, allow specifying whole grid (not just resolution)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '121449200'
+ValidationKey: '121782300'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 6.14.0
-date-released: '2024-02-27'
+version: 6.15.0
+date-released: '2024-03-20'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.14.0.9001
-Date: 2024-02-27
+Version: 6.15.0
+Date: 2024-03-20
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.14.0
+Version: 6.14.0.9001
 Date: 2024-02-27
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/extend.R
+++ b/R/extend.R
@@ -36,9 +36,13 @@ extend <- function(x,
     }
   } else {
     x <- x[sparseCoords %in% coords, , ]
-    sparseCoords <- paste0(getItems(x, "x", full = TRUE),
-                           ".",
-                           getItems(x, "y", full = TRUE))
+    if (length(x) > 0) {
+      sparseCoords <- paste0(getItems(x, "x", full = TRUE),
+                             ".",
+                             getItems(x, "y", full = TRUE))
+    } else {
+      sparseCoords <- character(0)
+    }
   }
 
   subdims1 <- getSets(x)[grep("^d1\\.", names(getSets(x)))]

--- a/R/extend.R
+++ b/R/extend.R
@@ -14,7 +14,8 @@
 extend <- function(x,
                    xRange = c(-179.75, 179.75),
                    yRange = c(89.75, -89.75),
-                   res = NULL) {
+                   res = NULL,
+                   checkInRange = TRUE) {
   stopifnot(length(xRange) == 2, length(yRange) == 2)
   if (is.null(res)) {
     res <- guessResolution(x)
@@ -28,9 +29,16 @@ extend <- function(x,
   sparseCoords <- paste0(getItems(x, "x", full = TRUE),
                          ".",
                          getItems(x, "y", full = TRUE))
-  if (!all(sparseCoords %in% coords)) {
-    stop("The coordinates of the input object are not a subset of the extended coordinates. ",
-         "Try changing res, xRange or yRange.")
+  if (checkInRange) {
+    if (!all(sparseCoords %in% coords)) {
+      stop("The coordinates of the input object are not a subset of the extended coordinates. ",
+           "Try changing res, xRange or yRange.")
+    }
+  } else {
+    x <- x[sparseCoords %in% coords, , ]
+    sparseCoords <- paste0(getItems(x, "x", full = TRUE),
+                           ".",
+                           getItems(x, "y", full = TRUE))
   }
 
   subdims1 <- getSets(x)[grep("^d1\\.", names(getSets(x)))]

--- a/R/writeNC.R
+++ b/R/writeNC.R
@@ -7,7 +7,7 @@
 #' @param compression Level of compression to use (1-9), NA for no compression
 #' @param missval The value that encodes NA in the resulting netCDF file
 #' @param gridDefinition A vector of 5 numeric values: c(xMin, xMax, yMin, yMax, resolution).
-#' Use c(-179.75, 179.75, -89.75, 89.75), 0.5) to write a standard 0.5-degree-resolution
+#' Use c(-179.75, 179.75, -89.75, 89.75, 0.5) to write a standard 0.5-degree-resolution
 #' lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution
 #' @param zname Name of the z dimension in the netCDF file
 #' @param chunkSize Data is written in dense grid chunks of this size,
@@ -28,8 +28,8 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
     coords <- getCoords(x)
     firstX <- min(coords$x)
     lastX <- max(coords$x)
-    firstY <- min(coords$y)
-    lastY <- max(coords$y)
+    firstY <- max(coords$y)
+    lastY <- min(coords$y)
     res <- guessResolution(coords)
   } else {
     stopifnot(length(gridDefinition) == 5,
@@ -41,8 +41,8 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
     lastY <- gridDefinition[3]
     res <- gridDefinition[5]
   }
-  xCoords <- seq(min(coords$x), max(coords$x), res)
-  yCoords <- seq(max(coords$y), min(coords$y), -res)
+  xCoords <- seq(firstX, lastX, res)
+  yCoords <- seq(firstY, lastY, -res)
 
   if (zname != "time") {
     message("terra will not recognize zname != 'time' as time dimension")

--- a/R/writeNC.R
+++ b/R/writeNC.R
@@ -74,19 +74,17 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
     ncdf4::ncatt_put(nc, "time", "axis", "T")
   }
 
+  messageIf(progress, "Writing ", filename)
+
   nYears <- max(1, length(getYears(x)))
   rowsPerChunk <- max(1, floor(chunkSize / nYears / length(xCoords)))
   for (iVariable in seq_along(getItems(x, 3))) {
     vname <- getItems(x, 3)[iVariable]
-    if (progress) {
-      message(iVariable, "/", length(getItems(x, 3)), " Writing ", vname)
-    }
+    messageIf(progress, iVariable, "/", length(getItems(x, 3)), " Writing ", vname)
     if (is.finite(chunkSize)) {
       startRows <- seq.int(1, length(yCoords), rowsPerChunk)
       for (iStartRow in seq_along(startRows)) {
-        if (progress) {
-          message("Writing chunk ", iStartRow, "/", length(startRows))
-        }
+        messageIf(progress, "Writing chunk ", iStartRow, "/", length(startRows))
         startRow <- startRows[iStartRow]
         chunk <- extend(x[, , vname],
                         gridDefinition = c(firstX, lastX,
@@ -102,5 +100,11 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
     } else {
       ncdf4::ncvar_put(nc, vname, extend(x[, , vname], gridDefinition = gridDefinition))
     }
+  }
+}
+
+messageIf <- function(condition, ...) {
+  if (condition) {
+    message(...)
   }
 }

--- a/R/writeNC.R
+++ b/R/writeNC.R
@@ -57,7 +57,8 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
                   ncdf4::ncdim_def("lat", "degrees_north", yCoords))
   hasTime <- !is.null(getItems(x, 2))
   if (hasTime) {
-    dimVars <- c(dimVars, list(ncdf4::ncdim_def(zname, "years since 0", getYears(x, as.integer = TRUE), unlim = TRUE)))
+    dimVars <- c(dimVars, list(ncdf4::ncdim_def(zname, "years since 0",
+                                                getYears(x, as.integer = TRUE), unlim = TRUE)))
   }
   vars <- lapply(getItems(x, 3), function(vname) {
     return(ncdf4::ncvar_def(vname, units = unit, dim = dimVars,

--- a/R/writeNC.R
+++ b/R/writeNC.R
@@ -3,14 +3,18 @@
 #' @param x A magpie object
 #' @param filename Name of the netCDF file to write
 #' @param unit Unit of the data, to omit pass "" (empty string)
-#' @param ... For future expansion.
+#' @param ... For future expansion
 #' @param compression Level of compression to use (1-9), NA for no compression
 #' @param missval The value that encodes NA in the resulting netCDF file
-#' @param res Resolution of the data, if not provided it will be guessed
+#' @param gridDefinition A vector of 5 numeric values: c(xMin, xMax, yMin, yMax, resolution).
+#' Use c(-179.75, 179.75, -89.75, 89.75), 0.5) to write a standard 0.5-degree-resolution
+#' lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution
 #' @param zname Name of the z dimension in the netCDF file
+#' @param chunkSize Data is written in dense grid chunks of this size,
+#' smaller values reduce memory footprint, but increase write time
 #' @author Pascal Sauer
 writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
-                    res = NULL, zname = "time") {
+                    gridDefinition = NULL, zname = "time", chunkSize = 250000) {
   if (!requireNamespace("ncdf4", quietly = TRUE)) {
     stop("The ncdf4 package is required to write netCDF files, please install it.")
   }
@@ -20,10 +24,25 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
     stop("Unknown argument passed to writeNC: ", paste(...names(), collapse = ", "))
   }
 
-  # magclass objects are sparse, fill gaps with NA
-  coords <- getCoords(x)
-  x <- extend(x, xRange = c(min(coords$x), max(coords$x)), yRange = c(max(coords$y), min(coords$y)), res = res)
-  coords <- getCoords(x)
+  if (is.null(gridDefinition)) {
+    coords <- getCoords(x)
+    firstX <- min(coords$x)
+    lastX <- max(coords$x)
+    firstY <- min(coords$y)
+    lastY <- max(coords$y)
+    res <- guessResolution(coords)
+  } else {
+    stopifnot(length(gridDefinition) == 5,
+              gridDefinition[1] < gridDefinition[2],
+              gridDefinition[3] < gridDefinition[4])
+    firstX <- gridDefinition[1]
+    lastX <- gridDefinition[2]
+    firstY <- gridDefinition[4]
+    lastY <- gridDefinition[3]
+    res <- gridDefinition[5]
+  }
+  xCoords <- seq(min(coords$x), max(coords$x), res)
+  yCoords <- seq(max(coords$y), min(coords$y), -res)
 
   if (zname != "time") {
     message("terra will not recognize zname != 'time' as time dimension")
@@ -34,9 +53,10 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
   }
 
   # create netCDF file
-  dimVars <- list(ncdf4::ncdim_def("lon", "degrees_east", unique(coords$x)),
-                  ncdf4::ncdim_def("lat", "degrees_north", unique(coords$y)))
-  if (!is.null(getItems(x, 2))) {
+  dimVars <- list(ncdf4::ncdim_def("lon", "degrees_east", xCoords),
+                  ncdf4::ncdim_def("lat", "degrees_north", yCoords))
+  hasTime <- !is.null(getItems(x, 2))
+  if (hasTime) {
     dimVars <- c(dimVars, list(ncdf4::ncdim_def(zname, "years since 0", getYears(x, as.integer = TRUE), unlim = TRUE)))
   }
   vars <- lapply(getItems(x, 3), function(vname) {
@@ -47,11 +67,21 @@ writeNC <- function(x, filename, unit, ..., compression = 2, missval = NA,
   nc <- ncdf4::nc_create(filename, vars = vars)
   withr::defer(ncdf4::nc_close(nc))
 
-  if (!is.null(getItems(x, 2)) && zname == "time") {
+  if (hasTime && zname == "time") {
     ncdf4::ncatt_put(nc, "time", "axis", "T")
   }
 
+  nYears <- max(1, length(getYears(x)))
+  rowsPerChunk <- max(1, floor(chunkSize / nYears / length(xCoords)))
   for (vname in getItems(x, 3)) {
-    ncdf4::ncvar_put(nc, vname, x[, , vname])
+    for (i in seq.int(1, length(yCoords), rowsPerChunk)) {
+      chunk <- extend(x[, , vname], c(firstX, lastX),
+                      c(yCoords[i], yCoords[min(i + rowsPerChunk - 1, length(yCoords))]),
+                      res = res, checkInRange = FALSE)
+      ncdf4::ncvar_put(nc, vname, chunk,
+                       start = c(1, i, if (hasTime) 1),
+                       count = c(-1, length(chunk) / nYears / length(xCoords),
+                                 if (hasTime) -1))
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.14.0**
+R package **magclass**, version **6.15.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P (2024). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.14.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P (2024). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.15.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +65,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer},
   year = {2024},
-  note = {R package version 6.14.0},
+  note = {R package version 6.15.0},
   url = {https://github.com/pik-piam/magclass},
   doi = {10.5281/zenodo.1158580},
 }

--- a/man/extend.Rd
+++ b/man/extend.Rd
@@ -4,7 +4,13 @@
 \alias{extend}
 \title{extend}
 \usage{
-extend(x, xRange = c(-179.75, 179.75), yRange = c(89.75, -89.75), res = NULL)
+extend(
+  x,
+  xRange = c(-179.75, 179.75),
+  yRange = c(89.75, -89.75),
+  res = NULL,
+  checkInRange = TRUE
+)
 }
 \arguments{
 \item{x}{A magpie object}

--- a/man/extend.Rd
+++ b/man/extend.Rd
@@ -4,25 +4,20 @@
 \alias{extend}
 \title{extend}
 \usage{
-extend(
-  x,
-  xRange = c(-179.75, 179.75),
-  yRange = c(89.75, -89.75),
-  res = NULL,
-  checkInRange = TRUE
-)
+extend(x, gridDefinition = NULL, crop = FALSE)
 }
 \arguments{
 \item{x}{A magpie object}
 
-\item{xRange}{Range of x coordinates, in ascending order when writing to netCDF}
+\item{gridDefinition}{A vector of 5 numeric values: c(xMin, xMax, yMin, yMax, resolution).
+Use c(-179.75, 179.75, -89.75, 89.75, 0.5) to extend to a standard 0.5-degree-resolution
+lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution.}
 
-\item{yRange}{Range of y coordinates, in descending order when writing to netCDF}
-
-\item{res}{Resolution of the data, if not provided it will be guessed}
+\item{crop}{If TRUE, discard cells from x which are not in the gridDefinition grid. If FALSE,
+throw an error if the coordinates of x are not a subset of the extended coordinates.}
 }
 \value{
-An extended magpie object with the same data as x and gaps filled with NA
+Magpie object x with dense grid according to gridDefinition, gaps filled with NA.
 }
 \description{
 Extend a magpie object to a dense grid based on the given xRange, yRange and resolution.

--- a/man/writeNC.Rd
+++ b/man/writeNC.Rd
@@ -30,7 +30,7 @@ writeNC(
 \item{missval}{The value that encodes NA in the resulting netCDF file}
 
 \item{gridDefinition}{A vector of 5 numeric values: c(xMin, xMax, yMin, yMax, resolution).
-Use c(-179.75, 179.75, -89.75, 89.75), 0.5) to write a standard 0.5-degree-resolution
+Use c(-179.75, 179.75, -89.75, 89.75, 0.5) to write a standard 0.5-degree-resolution
 lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution}
 
 \item{zname}{Name of the z dimension in the netCDF file}

--- a/man/writeNC.Rd
+++ b/man/writeNC.Rd
@@ -11,8 +11,9 @@ writeNC(
   ...,
   compression = 2,
   missval = NA,
-  res = NULL,
-  zname = "time"
+  gridDefinition = NULL,
+  zname = "time",
+  chunkSize = 250000
 )
 }
 \arguments{
@@ -22,15 +23,20 @@ writeNC(
 
 \item{unit}{Unit of the data, to omit pass "" (empty string)}
 
-\item{...}{For future expansion.}
+\item{...}{For future expansion}
 
 \item{compression}{Level of compression to use (1-9), NA for no compression}
 
 \item{missval}{The value that encodes NA in the resulting netCDF file}
 
-\item{res}{Resolution of the data, if not provided it will be guessed}
+\item{gridDefinition}{A vector of 5 numeric values: c(xMin, xMax, yMin, yMax, resolution).
+Use c(-179.75, 179.75, -89.75, 89.75), 0.5) to write a standard 0.5-degree-resolution
+lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution}
 
 \item{zname}{Name of the z dimension in the netCDF file}
+
+\item{chunkSize}{Data is written in dense grid chunks of this size,
+smaller values reduce memory footprint, but increase write time}
 }
 \description{
 Write a magpie object to a netCDF file

--- a/man/writeNC.Rd
+++ b/man/writeNC.Rd
@@ -13,7 +13,8 @@ writeNC(
   missval = NA,
   gridDefinition = NULL,
   zname = "time",
-  chunkSize = 250000
+  chunkSize = Inf,
+  progress = FALSE
 )
 }
 \arguments{
@@ -35,8 +36,10 @@ lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution}
 
 \item{zname}{Name of the z dimension in the netCDF file}
 
-\item{chunkSize}{Data is written in dense grid chunks of this size,
-smaller values reduce memory footprint, but increase write time}
+\item{chunkSize}{Data is written in dense grid chunks of at most this size,
+smaller values reduce memory footprint, but increase write time.}
+
+\item{progress}{If TRUE, print progress messages}
 }
 \description{
 Write a magpie object to a netCDF file

--- a/man/writeNC.Rd
+++ b/man/writeNC.Rd
@@ -13,7 +13,6 @@ writeNC(
   missval = NA,
   gridDefinition = NULL,
   zname = "time",
-  chunkSize = Inf,
   progress = FALSE
 )
 }
@@ -35,9 +34,6 @@ Use c(-179.75, 179.75, -89.75, 89.75, 0.5) to write a standard 0.5-degree-resolu
 lon/lat grid. If NULL, use min/max of coordinates in x and guessResolution}
 
 \item{zname}{Name of the z dimension in the netCDF file}
-
-\item{chunkSize}{Data is written in dense grid chunks of at most this size,
-smaller values reduce memory footprint, but increase write time.}
 
 \item{progress}{If TRUE, print progress messages}
 }

--- a/tests/testthat/test-extend.R
+++ b/tests/testthat/test-extend.R
@@ -2,20 +2,27 @@ test_that("extend works", {
   animal <- maxample("animal")
   # shuffle first dim to ensure order does not matter
   animal <- animal[sample(seq_along(getItems(animal, 1))), , ]
+  animalCoords <- getCoords(animal)
   expect_identical(guessResolution(animal), 0.5)
 
   x <- extend(animal)
-  expectedCoords <- expand.grid(x = seq(-179.75, 179.75, 0.5),
-                                y = seq(89.75, -89.75, -0.5),
+  expectedCoords <- expand.grid(x = seq(min(animalCoords$x), max(animalCoords$x), 0.5),
+                                y = seq(max(animalCoords$y), min(animalCoords$y), -0.5),
                                 KEEP.OUT.ATTRS = FALSE)
   expect_identical(getCoords(x), expectedCoords)
   expect_identical(getSets(x), getSets(animal))
   expect_identical(getItems(x[getItems(animal, 1), , ], 1), getItems(animal, 1))
 
-  expect_error(extend(animal, res = 1),
+  expect_error(extend(animal, gridDefinition = c(3.25, 6.75, 53.25, 49.75, 1)),
                "The coordinates of the input object are not a subset of the extended coordinates")
 
-  x <- extend(animal, xRange = c(-3.25, 16.75), yRange = c(63.25, -59.75), res = 0.25)
+  x <- extend(animal, gridDefinition = c(3.25, 6.75, 53.25, 49.75, 1), crop = TRUE)
+  expectedCoords <- expand.grid(x = seq(3.25, 6.75, 1),
+                                y = seq(53.25, 49.75, -1),
+                                KEEP.OUT.ATTRS = FALSE)
+  expect_identical(getCoords(x), expectedCoords)
+
+  x <- extend(animal, gridDefinition = c(-3.25, 16.75, 63.25, -59.75, 0.25))
 
   expectedCoords <- expand.grid(x = seq(-3.25, 16.75, 0.25),
                                 y = seq(63.25, -59.75, -0.25),
@@ -26,10 +33,8 @@ test_that("extend works", {
   animal2 <- dimOrder(animal, c(3, 4, 2, 1), dim = 1)
   expect_identical(names(dimnames(animal2))[1], "country.cell.y.x")
   x <- extend(animal2)
-  expectedCoords <- expand.grid(x = seq(-179.75, 179.75, 0.5),
-                                y = seq(89.75, -89.75, -0.5),
+  expectedCoords <- expand.grid(x = seq(min(animalCoords$x), max(animalCoords$x), 0.5),
+                                y = seq(max(animalCoords$y), min(animalCoords$y), -0.5),
                                 KEEP.OUT.ATTRS = FALSE)
   expect_identical(getCoords(x), expectedCoords)
 })
-
-# TODO test checkInRange

--- a/tests/testthat/test-extend.R
+++ b/tests/testthat/test-extend.R
@@ -31,3 +31,5 @@ test_that("extend works", {
                                 KEEP.OUT.ATTRS = FALSE)
   expect_identical(getCoords(x), expectedCoords)
 })
+
+# TODO test checkInRange


### PR DESCRIPTION
Instead of extending the whole magpie object to a dense raster, only extend the part with the variable that is about to be written to reduce the memory required. There was also a chunk-based solution implemented, but it was not useful in mrdownscale (just extending for a single variable was already doing the trick), and too complex to just stay around in case someone needs it, so it was removed with a comment hinting at the commit where it can be found.