### PR TITLE
Verbose mbind() Error Message on Multiple Differing Dimensions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '122203328'
+ValidationKey: '1222642778871'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 6.15.2
-date-released: '2024-05-21'
+version: 6.15.2.9001
+date-released: '2024-05-28'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.15.2
-Date: 2024-05-21
+Version: 6.15.2.9001
+Date: 2024-05-28
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut", "cre")),

--- a/R/mbind.R
+++ b/R/mbind.R
@@ -76,46 +76,46 @@ mbind <- function(...) { #nolint
          " data objects! Cannot handle this case!")
   }
 
-  diffall <- c('spatial' = diffspat, 'temporal' = difftemp, 'data' = diffdata)
+  diffall <- c("spatial" = diffspat, "temporal" = difftemp, "data" = diffdata)
   if (1 < sum(diffall)) {
     msg <- c("Cannot handle objects!",
-             paste(
-               paste(head(names(diffall)[diffall], n = -1),
-                     collapse = ", "),
-                 tail(names(diffall)[diffall], n = 1),
-               sep = " as well as "),
+             paste(paste(head(names(diffall)[diffall], n = -1),
+                         collapse = ", "),
+                   tail(names(diffall)[diffall], n = 1),
+                   sep = " as well as "),
              "dimensions differ!")
     substr(msg[2], 1, 1) <- toupper(substr(msg[2], 1, 1))
 
-    msg <- paste(
-      c(paste(msg, collapse = " "),
-        "  Differences from first mbind() input:",
-        vapply(which(diffall), function(i) {
+    msg <- paste(c(paste(msg, collapse = " "),
+                   "  Differences from first mbind() input:",
+                   vapply(which(diffall), function(i) {
 
-          lhs <- getItems(inputs[[1]], dim = i)
-          rhs <- Reduce(union, lapply(tail(inputs, n = -1), getItems, dim = i))
+                     lhs <- getItems(inputs[[1]], dim = i)
+                     rhs <- Reduce(union, lapply(tail(inputs, n = -1),
+                                                 getItems, dim = i))
 
-          # do a kind of three-way diff
-          diff <- list('missing' = setdiff(lhs, rhs),
-                       ' having' = intersect(lhs, rhs),
-                       ' adding' = setdiff(rhs, lhs))
+                     # do a kind of three-way diff
+                     diff <- list("missing" = setdiff(lhs, rhs),
+                                  " having" = intersect(lhs, rhs),
+                                  " adding" = setdiff(rhs, lhs))
 
-          diff <- lapply(diff, function(x) {
-            if (4 < length(x)) {   # shorten to four elements, like str() does
-              x <- c(paste0("`", x[1:4], "`"), "...")
-            } else if (0 < length(x)) {
-              x <- paste0("`", x, "`")
-            }
-            return(paste(x, collapse = ", "))
-          })
+                     diff <- lapply(diff, function(x) {
+                       if (4 < length(x)) {
+                         # shorten to four elements, like str() does
+                         x <- c(paste0("`", x[1:4], "`"), "...")
+                       } else if (0 < length(x)) {
+                         x <- paste0("`", x, "`")
+                       }
+                       return(paste(x, collapse = ", "))
+                     })
 
-          # paste diff
-          d <- nzchar(diff)
-          paste(c(paste0("  ", names(diffall)[i], ":"),
-                  paste(paste0("      ", names(diff)[d], ":"), diff[d])),
-                collapse = "\n")
-        }, character(1))),
-      collapse = "\n")
+                     # paste diff
+                     d <- nzchar(diff)
+                     paste(c(paste0("  ", names(diffall)[i], ":"),
+                             paste(paste0("      ", names(diff)[d], ":"),
+                                   diff[d])),
+                           collapse = "\n")
+                   }, character(1))), collapse = "\n")
     stop(msg)
   }
 

--- a/R/mbind.R
+++ b/R/mbind.R
@@ -76,9 +76,49 @@ mbind <- function(...) { #nolint
          " data objects! Cannot handle this case!")
   }
 
-  if (diffspat && difftemp) stop("Cannot handle objects! Spatial as well as temporal dimensions differ!")
-  if (difftemp && diffdata) stop("Cannot handle objects! Data as well as temporal dimensions differ!")
-  if (diffdata && diffspat) stop("Cannot handle objects! Data as well as spatial dimensions differ!")
+  diffall <- c('spatial' = diffspat, 'temporal' = difftemp, 'data' = diffdata)
+  if (1 < sum(diffall)) {
+    msg <- c("Cannot handle objects!",
+             paste(
+               paste(head(names(diffall)[diffall], n = -1),
+                     collapse = ", "),
+                 tail(names(diffall)[diffall], n = 1),
+               sep = " as well as "),
+             "dimensions differ!")
+    substr(msg[2], 1, 1) <- toupper(substr(msg[2], 1, 1))
+
+    msg <- paste(
+      c(paste(msg, collapse = " "),
+        "  Differences from first mbind() input:",
+        vapply(which(diffall), function(i) {
+
+          lhs <- getItems(inputs[[1]], dim = i)
+          rhs <- Reduce(union, lapply(tail(inputs, n = -1), getItems, dim = i))
+
+          # do a kind of three-way diff
+          diff <- list('missing' = setdiff(lhs, rhs),
+                       ' having' = intersect(lhs, rhs),
+                       ' adding' = setdiff(rhs, lhs))
+
+          diff <- lapply(diff, function(x) {
+            if (4 < length(x)) {   # shorten to four elements, like str() does
+              x <- c(paste0("`", x[1:4], "`"), "...")
+            } else if (0 < length(x)) {
+              x <- paste0("`", x, "`")
+            }
+            return(paste(x, collapse = ", "))
+          })
+
+          # paste diff
+          d <- nzchar(diff)
+          paste(c(paste0("  ", names(diffall)[i], ":"),
+                  paste(paste0("      ", names(diff)[d], ":"), diff[d])),
+                collapse = "\n")
+        }, character(1))),
+      collapse = "\n")
+    stop(msg)
+  }
+
   if (difftemp) {
     if (length(years) != length(unique(years))) stop("Some years occur more than once!",
                                                      " Cannot handle this case!")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.15.2**
+R package **magclass**, version **6.15.2.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P (2024). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi: 10.5281/zenodo.1158580 (URL: https://doi.org/10.5281/zenodo.1158580), R package version 6.15.2, <URL: https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P (2024). _magclass: Data Class and Tools for Handling Spatial-Temporal Data_. doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, R package version 6.15.2.9001, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,7 +65,7 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer},
   year = {2024},
-  note = {R package version 6.15.2},
+  note = {R package version 6.15.2.9001},
   doi = {10.5281/zenodo.1158580},
   url = {https://github.com/pik-piam/magclass},
 }


### PR DESCRIPTION
Originates from pik-piam/remind2#604, discussed with @orichters and @fbenke-pik.
The idea is to have more information available in the error message for debugging.  To that end, `mbind()` does something like a three-way-diff, noting for all dimensions that differ (relative to the first input) which elements are missing, which are identical, and which are added.
```
A <- maxample('pop')[c('AFR', 'CPA', 'EUR', 'FSU', 'LAM', 'MEA', 'NAM'),,'A2']
B <- maxample('pop')[c('MEA', 'NAM', 'PAO', 'PAS'),,'B1']

mbind(A, B)

# Error in mbind(A, B) : 
#   Cannot handle objects! Spatial as well as data dimensions differ!
#   Differences from first mbind() input:
#   spatial:
#       missing: `AFR`, `CPA`, `EUR`, `FSU`, ...
#        having: `MEA`, `NAM`
#        adding: `PAO`, `PAS`
#   data:
#       missing: `A2`
#        adding: `B1`
```
The change only affects the "Cannot handle objects!" error, so no external code that actually works.