### PR TITLE
fix partial matching

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '124192984'
+ValidationKey: '124545540'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 6.17.2
-date-released: '2025-02-03'
+version: 6.18.0
+date-released: '2025-03-06'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.17.2
-Date: 2025-02-03
+Version: 6.18.0
+Date: 2025-03-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut", "cre")),

--- a/R/as.SpatRaster.R
+++ b/R/as.SpatRaster.R
@@ -11,7 +11,7 @@
 #' @examples
 #'
 #' if (requireNamespace("terra", quietly = TRUE)) {
-#'    r <- terra::rast(ncols = 360, nrows = 180, nl = 4)
+#'    r <- terra::rast(ncols = 360, nrows = 180, nlyrs = 4)
 #'    r[85:89, 176:179] <- (1:20 %*% t(1:4))
 #'    r[15:19, 76:79] <-   (10 + 1:20 %*% t(1:4))
 #'    names(r) <- c("y2000..bla", "y2001..bla", "y2000..blub", "y2001..blub")

--- a/R/as.SpatVector.R
+++ b/R/as.SpatVector.R
@@ -11,7 +11,7 @@
 #' @examples
 #'
 #' if (requireNamespace("terra", quietly = TRUE)) {
-#'    r <- terra::rast(ncols = 360, nrows = 180, nl = 4)
+#'    r <- terra::rast(ncols = 360, nrows = 180, nlyrs = 4)
 #'    r[85:89, 176:179] <- (1:20 %*% t(1:4))
 #'    r[15:19, 76:79] <-   (10 + 1:20 %*% t(1:4))
 #'    names(r) <- c("y2000..bla", "y2001..bla", "y2000..blub", "y2001..blub")

--- a/R/read.magpie.R
+++ b/R/read.magpie.R
@@ -108,7 +108,7 @@ read.magpie <- function(file_name, file_folder = "", file_type = NULL, # nolint:
     readMagpie <- as.magpie(x, tidy = TRUE,
                             spatial = grep(".spat", m$metadata$dimtype, fixed = TRUE),
                             temporal = grep(".temp", m$metadata$dimtype, fixed = TRUE),
-                            data = grep(".data", m$metadata$dimtype, fixed = TRUE))
+                            datacol = grep(".data", m$metadata$dimtype, fixed = TRUE))
     attr(readMagpie, "comment") <- m$comment
   } else if (fileType %in% c("asc", "nc", "grd", "tif")) {
     if (fileType == "nc") {

--- a/R/readMagpieOther.R
+++ b/R/readMagpieOther.R
@@ -1,7 +1,7 @@
 readMagpieOther <- function(fileName, fileType, comment.char = "*", check.names = FALSE) {  # nolint
   sep <- ifelse(fileType == "put", "\t", ",")
   # check for header
-  temp <- utils::read.csv(fileName, nrow = 1, header = FALSE, sep = sep, comment.char = comment.char,
+  temp <- utils::read.csv(fileName, nrows = 1, header = FALSE, sep = sep, comment.char = comment.char,
                           check.names = check.names, stringsAsFactors = TRUE)
 
   # check for numeric elements in first row, which means a missing header

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.17.2**
+R package **magclass**, version **6.18.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 6.17.2, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 6.18.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-02-03},
+  date = {2025-03-06},
   year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 6.17.2},
+  note = {Version: 6.18.0},
 }
 ```

--- a/man/as.SpatRaster.Rd
+++ b/man/as.SpatRaster.Rd
@@ -20,7 +20,7 @@ Convert magclass object to a SpatRaster object. Requires the terra package.
 \examples{
 
 if (requireNamespace("terra", quietly = TRUE)) {
-   r <- terra::rast(ncols = 360, nrows = 180, nl = 4)
+   r <- terra::rast(ncols = 360, nrows = 180, nlyrs = 4)
    r[85:89, 176:179] <- (1:20 \%*\% t(1:4))
    r[15:19, 76:79] <-   (10 + 1:20 \%*\% t(1:4))
    names(r) <- c("y2000..bla", "y2001..bla", "y2000..blub", "y2001..blub")

--- a/man/as.SpatVector.Rd
+++ b/man/as.SpatVector.Rd
@@ -20,7 +20,7 @@ as "geometry" attribute in "WKT" format. (see object "m" in example).
 \examples{
 
 if (requireNamespace("terra", quietly = TRUE)) {
-   r <- terra::rast(ncols = 360, nrows = 180, nl = 4)
+   r <- terra::rast(ncols = 360, nrows = 180, nlyrs = 4)
    r[85:89, 176:179] <- (1:20 \%*\% t(1:4))
    r[15:19, 76:79] <-   (10 + 1:20 \%*\% t(1:4))
    names(r) <- c("y2000..bla", "y2001..bla", "y2000..blub", "y2001..blub")

--- a/tests/testthat/test-raster.R
+++ b/tests/testthat/test-raster.R
@@ -5,7 +5,7 @@ test_that("terra conversion does not alter data", {
   for (i in c(0.5, 2)) {
     for (j in c(1, 4)) {
       for (t in c(1, 3)) {
-        r <- terra::rast(ncols = 360 / i, nrows = 180 / i, nl = j * t)
+        r <- terra::rast(ncols = 360 / i, nrows = 180 / i, nlyrs = j * t)
         if (t > 1) {
           years <- paste0("y", 1900 + 1:t)
           data  <- paste0("bla", 1:j)

--- a/tests/testthat/test-time_interpolate.R
+++ b/tests/testthat/test-time_interpolate.R
@@ -3,10 +3,11 @@ attr(p, "Metadata") <- NULL
 
 
 test_that("time interpolate works", {
-  expect_silent(p2 <- time_interpolate(p, "y2000", integrate = TRUE))
+  expect_silent(p2 <- time_interpolate(p, "y2000", integrate_interpolated_years = TRUE))
   expect_identical(p2[, 2000, , invert = TRUE], p)
   expect_true(all(p2[, 2000, ] - magpply(p[, c(1995, 2005), ], mean, DIM = 2) == 0))
-  expect_silent(p3 <- time_interpolate(p, c(1980, 2000), integrate = TRUE, extrapolation_type = "constant"))
+  expect_silent(p3 <- time_interpolate(p, c(1980, 2000), integrate_interpolated_years = TRUE,
+                                       extrapolation_type = "constant"))
   expect_identical(p3[, c(1980, 2000), , invert = TRUE], p)
   expect_true(all(p3[, 1980, ] - setYears(p3[, 1995, ], NULL) == 0))
   expect_error(time_interpolate(1), "Invalid data format")
@@ -15,7 +16,7 @@ test_that("time interpolate works", {
   expect_true(all(dimSums(p4, dim = 2) - 2 * p[, 1, ] == 0))
   expect_silent(p5 <- time_interpolate(p[, 1, ], c(1900, 1995, 2100)))
   expect_true(all(dimSums(p5, dim = 2) - 3 * p[, 1, ] == 0))
-  expect_silent(p6 <- time_interpolate(p[, 1, ], c(1900, 1995, 2100), integrate = TRUE))
+  expect_silent(p6 <- time_interpolate(p[, 1, ], c(1900, 1995, 2100), integrate_interpolated_years = TRUE))
   expect_identical(p5, p6)
 })
 


### PR DESCRIPTION
As discussed in https://github.com/pik-piam/madrat/issues/240 magclass was using quite some partial matching (thanks for pointing out some parts already @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q!). This PR should fix most of it. Essentially I just ran buildLibrary with
```
options(warn = 1,
	warnPartialMatchArgs = TRUE,
	warnPartialMatchAttr = TRUE,
	warnPartialMatchDollar = TRUE)
```
and fixed the warnings that came up.