### PR TITLE
Improve performance of as.data.frame

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '126479070'
+ValidationKey: '126782260'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 6.21.0
-date-released: '2025-10-06'
+version: 6.22.0
+date-released: '2025-10-22'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 6.21.0
-Date: 2025-10-06
+Version: 6.22.0
+Date: 2025-10-22
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", 
     comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut", "cre")),

--- a/R/as.data.frame.R
+++ b/R/as.data.frame.R
@@ -57,7 +57,7 @@ setMethod("as.data.frame",
       }
       if (all(grepl(".", x[[3]], fixed = TRUE))) {
         levels(x[[3]]) <- gsub("\\.$", "\\.STRINGTORESETAG", levels(x[[3]]))
-        tmp <- data.frame(t(matrix(unlist(strsplit(as.character(x[[3]]), split = "\\.")), ncol = nrow(x))),
+        tmp <- data.frame(t(matrix(unlist(strsplit(as.character(x[[3]]), split = ".", fixed = TRUE)), ncol = nrow(x))),
                           stringsAsFactors = FALSE)
         for (i in seq_len(ncol(tmp))) {
           tmp[[i]] <- factor(tmp[[i]], unique(tmp[[i]]))

--- a/R/as.data.frame.R
+++ b/R/as.data.frame.R
@@ -91,7 +91,7 @@ asDataFrameX <- function(x, raw, stringsAsFactors = FALSE) { # nolint
   types <- c(".spat", ".temp", ".data")
   for (i in 3:1) {
     if (grepl(".", names(x)[i], fixed = TRUE)) {
-      tmp <- data.frame(t(matrix(unlist(strsplit(as.character(x[[i]]), split = "\\.")), ncol = nrow(x))),
+      tmp <- data.frame(t(matrix(unlist(strsplit(as.character(x[[i]]), split = ".", fixed = TRUE)), ncol = nrow(x))),
                         stringsAsFactors = FALSE)
       names(tmp) <-  strsplit(names(x)[i], split = "\\.")[[1]]
       if (i == 1) {
@@ -116,7 +116,7 @@ asDataFrameX <- function(x, raw, stringsAsFactors = FALSE) { # nolint
         }
         # convert coordinates
         if (grepl("^-?[0-9]+p-?[0-9]+", x[[i]][1]) && all(grepl("^-?[0-9]+p-?[0-9]+", x[[i]]))) {
-          x[[i]] <- sub("p", ".", x[[i]])
+          x[[i]] <- sub("p", ".", x[[i]], fixed = TRUE)
         }
       }
       x[[i]] <- type.convert(x[[i]], as.is = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **6.21.0**
+R package **magclass**, version **6.22.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 6.21.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 6.22.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-10-06},
+  date = {2025-10-22},
   year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 6.21.0},
+  note = {Version: 6.22.0},
 }
 ```


### PR DESCRIPTION
Two minor changes improves the performance of `as.data.frame` by almost 50% (A magpie object from a 90MB .mcz converts in 96 seconds instead of 180 seconds).