### PR TITLE
faster add dimension

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '143328000420'
+ValidationKey: '14502460'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '14312317'
+ValidationKey: '143328000420'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.0.1.9001
-date-released: '2025-11-28'
+version: 7.1.0
+date-released: '2025-12-04'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.0.1
-date-released: '2025-11-25'
+version: 7.0.1.9001
+date-released: '2025-11-28'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.0.1
-Date: 2025-11-25
+Version: 7.0.1.9001
+Date: 2025-11-28
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.0.1.9001
+Version: 7.0.1.9002
 Date: 2025-11-28
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.0.1.9002
-Date: 2025-11-28
+Version: 7.1.0
+Date: 2025-12-04
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -9,7 +9,7 @@
 #' @param add The name of the new dimension
 #' @param nm The name of the first entry in dimension "add".
 #' @return The extended MAgPIE object
-#' @author Jan Philipp Dietrich, Benjamin Bodirsky
+#' @author Jan Philipp Dietrich, Benjamin Bodirsky, Pascal Sauer
 #' @seealso \code{\link{add_columns}},\code{\link{mbind}}
 #' @examples
 #'

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -55,29 +55,3 @@ add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: ob
   }
   return(x)
 }
-
-add_dimension_old <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
-  x <- clean_magpie(x, what = "sets")
-  if (is.null(add)) {
-    # create non-existing variant of dimension name starting with "new"
-    sets <- getSets(x, fulldim = TRUE)
-    add <- tail(make.unique(c(sets, "new"), sep = ""), 1)
-  } else if (add %in% getSets(x, fulldim = TRUE)) {
-    stop("Dimension \"", add, "\" does already exist. Please use a different name!")
-  }
-  maindim <- floor(dim)
-  subdim  <- as.integer(sub("^.\\.", "", as.character(dim)))
-  if (length(nm) > 1) {
-    expand <- rep(seq_len(dim(x)[maindim]), length(nm))
-    x <- x[expand, dim = maindim]
-  }
-  items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
-  olddims <- seq_along(items)
-  items[[add]] <- rep(nm, each = dim(x)[maindim] / length(nm))
-  reorder <- c(olddims[olddims < subdim], length(items), olddims[olddims >= subdim])
-  items <- items[reorder]
-  items <- items[!vapply(items, is.null, logical(1))]
-  getItems(x, dim = maindim, raw = TRUE) <- apply(as.data.frame(items), 1, paste, collapse = ".")
-  getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
-  return(x)
-}

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -18,6 +18,35 @@
 #' str(add_dimension(a, dim = 2.3, nm = paste0("d", 1:3)))
 #' @export
 add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
+  if (length(nm) > 1) {
+    return(add_dimension_old(x, dim, add, nm))
+  }
+  x <- clean_magpie(x, what = "sets")
+  if (is.null(add)) {
+    # create non-existing variant of dimension name starting with "new"
+    sets <- getSets(x, fulldim = TRUE)
+    add <- tail(make.unique(c(sets, "new"), sep = ""), 1)
+  } else if (add %in% getSets(x, fulldim = TRUE)) {
+    stop("Dimension \"", add, "\" does already exist. Please use a different name!")
+  }
+  maindim <- floor(dim)
+  subdim  <- as.integer(sub("^.\\.", "", as.character(dim)))
+  if (length(nm) > 1) {
+    expand <- rep(seq_len(dim(x)[maindim]), length(nm))
+    x <- x[expand, dim = maindim]
+  }
+  items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
+  before <- seq_len(subdim - 1)
+  after <- setdiff(seq_along(items), before)
+  items <- c(items[before], nm, items[after])
+  names(items)[subdim] <- add
+  items <- Filter(Negate(is.null), items)
+  getItems(x, dim = maindim, raw = TRUE) <- do.call(function(...) paste(..., sep = "."), items)
+  getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
+  return(x)
+}
+
+add_dimension_old <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
   x <- clean_magpie(x, what = "sets")
   if (is.null(add)) {
     # create non-existing variant of dimension name starting with "new"

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -31,16 +31,53 @@ add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: ob
   if (length(nm) > 1) {
     expand <- rep(seq_len(dim(x)[maindim]), length(nm))
     x <- x[expand, dim = maindim]
+    nm <- rep(nm, each = dim(x)[maindim] / length(nm))
+  }
+  if (is.null(getItems(x, dim = maindim))) {
+    getItems(x, dim = maindim) <- nm
+    getSets(x, fulldim = FALSE)[maindim] <- add
+  } else if (subdim == 1) {
+    getItems(x, dim = maindim, raw = TRUE) <- paste0(nm, ".", getItems(x, dim = maindim, full = TRUE))
+    getSets(x, fulldim = FALSE)[maindim] <- paste0(add, ".", getSets(x, fulldim = FALSE)[maindim])
+  } else if (subdim > ndim(x, maindim)) {
+    getItems(x, dim = maindim, raw = TRUE) <- paste0(getItems(x, dim = maindim, full = TRUE), ".", nm)
+    getSets(x, fulldim = FALSE)[maindim] <- paste0(getSets(x, fulldim = FALSE)[maindim], ".", add)
+  } else {
+    # this else branch can solve any case, the previous 3 are just faster implementations for common special cases
+    items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
+    before <- seq_len(subdim - 1)
+    after <- setdiff(seq_along(items), before)
+    items <- c(items[before], list(nm), items[after])
+    names(items)[subdim] <- add
+    items <- Filter(Negate(is.null), items)
+    getItems(x, dim = maindim, raw = TRUE) <- do.call(function(...) paste(..., sep = "."), items)
+    getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
+  }
+  return(x)
+}
+
+add_dimension_old <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
+  x <- clean_magpie(x, what = "sets")
+  if (is.null(add)) {
+    # create non-existing variant of dimension name starting with "new"
+    sets <- getSets(x, fulldim = TRUE)
+    add <- tail(make.unique(c(sets, "new"), sep = ""), 1)
+  } else if (add %in% getSets(x, fulldim = TRUE)) {
+    stop("Dimension \"", add, "\" does already exist. Please use a different name!")
+  }
+  maindim <- floor(dim)
+  subdim  <- as.integer(sub("^.\\.", "", as.character(dim)))
+  if (length(nm) > 1) {
+    expand <- rep(seq_len(dim(x)[maindim]), length(nm))
+    x <- x[expand, dim = maindim]
   }
   items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
-  before <- seq_len(subdim - 1)
-  after <- setdiff(seq_along(items), before)
-  items <- c(items[before],
-             list(rep(nm, each = dim(x)[maindim] / length(nm))),
-             items[after])
-  names(items)[subdim] <- add
-  items <- Filter(Negate(is.null), items)
-  getItems(x, dim = maindim, raw = TRUE) <- do.call(function(...) paste(..., sep = "."), items)
+  olddims <- seq_along(items)
+  items[[add]] <- rep(nm, each = dim(x)[maindim] / length(nm))
+  reorder <- c(olddims[olddims < subdim], length(items), olddims[olddims >= subdim])
+  items <- items[reorder]
+  items <- items[!vapply(items, is.null, logical(1))]
+  getItems(x, dim = maindim, raw = TRUE) <- apply(as.data.frame(items), 1, paste, collapse = ".")
   getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
   return(x)
 }

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -34,7 +34,7 @@ add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: ob
     nm <- rep(nm, each = dim(x)[maindim] / length(nm))
   }
   if (is.null(getItems(x, dim = maindim))) {
-    getItems(x, dim = maindim) <- nm
+    getItems(x, dim = maindim, raw = TRUE) <- nm
     getSets(x, fulldim = FALSE)[maindim] <- add
   } else if (subdim == 1) {
     getItems(x, dim = maindim, raw = TRUE) <- paste0(nm, ".", getItems(x, dim = maindim, full = TRUE))

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -18,9 +18,6 @@
 #' str(add_dimension(a, dim = 2.3, nm = paste0("d", 1:3)))
 #' @export
 add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
-  if (length(nm) > 1) {
-    return(add_dimension_old(x, dim, add, nm))
-  }
   x <- clean_magpie(x, what = "sets")
   if (is.null(add)) {
     # create non-existing variant of dimension name starting with "new"
@@ -38,36 +35,12 @@ add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: ob
   items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
   before <- seq_len(subdim - 1)
   after <- setdiff(seq_along(items), before)
-  items <- c(items[before], nm, items[after])
+  items <- c(items[before],
+             list(rep(nm, each = dim(x)[maindim] / length(nm))),
+             items[after])
   names(items)[subdim] <- add
   items <- Filter(Negate(is.null), items)
   getItems(x, dim = maindim, raw = TRUE) <- do.call(function(...) paste(..., sep = "."), items)
-  getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
-  return(x)
-}
-
-add_dimension_old <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
-  x <- clean_magpie(x, what = "sets")
-  if (is.null(add)) {
-    # create non-existing variant of dimension name starting with "new"
-    sets <- getSets(x, fulldim = TRUE)
-    add <- tail(make.unique(c(sets, "new"), sep = ""), 1)
-  } else if (add %in% getSets(x, fulldim = TRUE)) {
-    stop("Dimension \"", add, "\" does already exist. Please use a different name!")
-  }
-  maindim <- floor(dim)
-  subdim  <- as.integer(sub("^.\\.", "", as.character(dim)))
-  if (length(nm) > 1) {
-    expand <- rep(seq_len(dim(x)[maindim]), length(nm))
-    x <- x[expand, dim = maindim]
-  }
-  items <- getItems(x, dim = maindim, split = TRUE, full = TRUE)
-  olddims <- seq_along(items)
-  items[[add]] <- rep(nm, each = dim(x)[maindim] / length(nm))
-  reorder <- c(olddims[olddims < subdim], length(items), olddims[olddims >= subdim])
-  items <- items[reorder]
-  items <- items[!vapply(items, is.null, logical(1))]
-  getItems(x, dim = maindim, raw = TRUE) <- apply(as.data.frame(items), 1, paste, collapse = ".")
   getSets(x, fulldim = FALSE)[maindim] <- paste(names(items), collapse = ".")
   return(x)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.0.1**
+R package **magclass**, version **7.0.1.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.0.1, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.0.1.9001, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-11-25},
+  date = {2025-11-28},
   year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.0.1},
+  note = {Version: 7.0.1.9001},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.0.1.9001**
+R package **magclass**, version **7.1.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.0.1.9001, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.1.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-11-28},
+  date = {2025-12-04},
   year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.0.1.9001},
+  note = {Version: 7.1.0},
 }
 ```

--- a/man/add_dimension.Rd
+++ b/man/add_dimension.Rd
@@ -32,5 +32,5 @@ str(add_dimension(a, dim = 2.3, nm = paste0("d", 1:3)))
 \code{\link{add_columns}},\code{\link{mbind}}
 }
 \author{
-Jan Philipp Dietrich, Benjamin Bodirsky
+Jan Philipp Dietrich, Benjamin Bodirsky, Pascal Sauer
 }

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -59,10 +59,10 @@ test_that("add_dimension can handle large objects", {
   weight <- new.magpie(to, fill = 0)
   idx <- sample(seq_len(ncells(weight)), 20)
   weight[idx, , ] <- runif(length(idx))
-  weight <- add_dimension(weight, 1.1)
-  weight <- add_dimension(weight, 1.1)
+  weight <- add_dimension(weight, 1.1, nm = "a")
+  weight <- add_dimension(weight, 1.8, nm = "b")
 
-  timed <- system.time(ad <- add_dimension(weight, 1.2))
+  timed <- system.time(add_dimension(weight, 1.2))
 
   expect_true(timed["elapsed"] < 0.5)
 })

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -51,15 +51,3 @@ test_that("add_dimension works objects with inconsistent set information", {
   expect_silent(b <- add_dimension(a))
   expect_identical(getItems(b, 3.1), "dummy")
 })
-
-test_that("add_dimension can handle large objects", {
-  x <- new.magpie(paste0("A", 1:4e5))
-  system.time(x <- add_dimension(x, 1.1, nm = "a"))
-  system.time(x <- add_dimension(x, 1.8, nm = "b"))
-  system.time(x <- add_dimension(x, 1.2))
-
-  x <- new.magpie(paste0("A", 1:4e5))
-  system.time(x <- add_dimension_old(x, 1.1, nm = "a"))
-  system.time(x <- add_dimension_old(x, 1.8, nm = "b"))
-  system.time(x <- add_dimension_old(x, 1.2))
-})

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -51,3 +51,18 @@ test_that("add_dimension works objects with inconsistent set information", {
   expect_silent(b <- add_dimension(a))
   expect_identical(getItems(b, 3.1), "dummy")
 })
+
+test_that("add_dimension can handle large objects", {
+  to <- Reduce(x = 1:26, init = NULL, f = function(total, i) {
+    return(c(total, paste0(LETTERS[i], seq_len(1000 * i))))
+  })
+  weight <- new.magpie(to, fill = 0)
+  idx <- sample(seq_len(ncells(weight)), 20)
+  weight[idx, , ] <- runif(length(idx))
+  weight <- add_dimension(weight, 1.1)
+  weight <- add_dimension(weight, 1.1)
+
+  timed <- system.time(ad <- add_dimension(weight, 1.2))
+
+  expect_true(timed["elapsed"] < 0.5)
+})

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -44,6 +44,8 @@ test_that("add_dimension works", {
   expect_silent(p <- add_dimension(p, 3.1))
   expect_silent(p <- add_dimension(p, 3.2))
   expect_identical(getSets(p, fulldim = FALSE)[3], "new.new1.scenario")
+  expect_silent(p <- add_dimension(p, 3.4))
+  expect_identical(getSets(p, fulldim = FALSE)[3], "new.new1.scenario.new2")
 
   p <- add_dimension(dimSums(p, 3), nm = c("a.b", "c.d"))
   expect_identical(getItems(p, 3), c("a.b", "c.d"))

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -53,16 +53,13 @@ test_that("add_dimension works objects with inconsistent set information", {
 })
 
 test_that("add_dimension can handle large objects", {
-  to <- Reduce(x = 1:26, init = NULL, f = function(total, i) {
-    return(c(total, paste0(LETTERS[i], seq_len(1000 * i))))
-  })
-  weight <- new.magpie(to, fill = 0)
-  idx <- sample(seq_len(ncells(weight)), 20)
-  weight[idx, , ] <- runif(length(idx))
-  weight <- add_dimension(weight, 1.1, nm = "a")
-  weight <- add_dimension(weight, 1.8, nm = "b")
+  x <- new.magpie(paste0("A", 1:4e5))
+  system.time(x <- add_dimension(x, 1.1, nm = "a"))
+  system.time(x <- add_dimension(x, 1.8, nm = "b"))
+  system.time(x <- add_dimension(x, 1.2))
 
-  timed <- system.time(add_dimension(weight, 1.2))
-
-  expect_true(timed["elapsed"] < 0.5)
+  x <- new.magpie(paste0("A", 1:4e5))
+  system.time(x <- add_dimension_old(x, 1.1, nm = "a"))
+  system.time(x <- add_dimension_old(x, 1.8, nm = "b"))
+  system.time(x <- add_dimension_old(x, 1.2))
 })

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -38,12 +38,15 @@ test_that("add_dimension works", {
                                                            type.species.color = "animal.rabbit.black")))
   expect_identical(add_dimension(a0, dim = 1), ref4)
   expect_identical(add_dimension(a0, dim = 1.2), ref4)
+
   p <- maxample("pop")
   expect_error(add_dimension(p, dim = 3.2, add = "scenario"), "Dimension .* does already exist")
-
   expect_silent(p <- add_dimension(p, 3.1))
   expect_silent(p <- add_dimension(p, 3.2))
   expect_identical(getSets(p, fulldim = FALSE)[3], "new.new1.scenario")
+
+  p <- add_dimension(dimSums(p, 3), nm = c("a.b", "c.d"))
+  expect_identical(getItems(p, 3), c("a.b", "c.d"))
 })
 
 test_that("add_dimension works objects with inconsistent set information", {


### PR DESCRIPTION
For testing I ran both the remind and magpie preprocessing on an initially empty cache.

new:
```r
> x <- new.magpie(paste0("A", 1:4e5))
> system.time(x <- add_dimension(x, 1.1, nm = "a"))
   user  system elapsed 
  0.139   0.000   0.139 
> system.time(x <- add_dimension(x, 1.8, nm = "b"))
   user  system elapsed 
  0.204   0.000   0.204 
> system.time(x <- add_dimension(x, 1.2))
   user  system elapsed 
  0.415   0.002   0.418
```

old:
```r
> x <- new.magpie(paste0("A", 1:4e5))
> system.time(x <- add_dimension_old(x, 1.1, nm = "a"))
   user  system elapsed 
  2.064   0.004   2.067 
> system.time(x <- add_dimension_old(x, 1.8, nm = "b"))
   user  system elapsed 
  2.612   0.011   2.622 
> system.time(x <- add_dimension_old(x, 1.2))
   user  system elapsed 
  2.200   0.015   2.215
```

(pure comparison code:)
```r
  x <- new.magpie(paste0("A", 1:4e5))
  system.time(x <- add_dimension(x, 1.1, nm = "a"))
  system.time(x <- add_dimension(x, 1.8, nm = "b"))
  system.time(x <- add_dimension(x, 1.2))

  x <- new.magpie(paste0("A", 1:4e5))
  system.time(x <- add_dimension_old(x, 1.1, nm = "a"))
  system.time(x <- add_dimension_old(x, 1.8, nm = "b"))
  system.time(x <- add_dimension_old(x, 1.2))
```