### PR TITLE
expand argument for add_dimension

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '14502460'
+ValidationKey: '14706720'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.1.0
+version: 7.2.0
 date-released: '2025-12-04'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.1.0
+Version: 7.2.0
 Date: 2025-12-04
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -7,7 +7,13 @@
 #' @param x MAgPIE object which should be extended.
 #' @param dim The dimension number of the new dimension (e.g. 3.1)
 #' @param add The name of the new dimension
-#' @param nm The name of the first entry in dimension "add".
+#' @param nm One or more names of items in the new dimension. If more than one
+#' is given, behavior depends on the expand argument.
+#' @param expand If TRUE, each item in nm is added to each item
+#' already present, resulting in e.g. `c("A.d1", "A.d2", "B.d1", "B.d2")`.
+#' Otherwise, length of nm must equal the number of items already present and
+#' they are simply added, resulting in e.g. `c("A.d1", "B.d2")`.
+#'
 #' @return The extended MAgPIE object
 #' @author Jan Philipp Dietrich, Benjamin Bodirsky
 #' @seealso \code{\link{add_columns}},\code{\link{mbind}}
@@ -17,7 +23,7 @@
 #' str(add_dimension(a, dim = 3.2))
 #' str(add_dimension(a, dim = 2.3, nm = paste0("d", 1:3)))
 #' @export
-add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: object_name_linter.
+add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy", expand = TRUE) { # nolint: object_name_linter.
   x <- clean_magpie(x, what = "sets")
   if (is.null(add)) {
     # create non-existing variant of dimension name starting with "new"
@@ -29,9 +35,14 @@ add_dimension <- function(x, dim = 3.1, add = NULL, nm = "dummy") { # nolint: ob
   maindim <- floor(dim)
   subdim  <- as.integer(sub("^.\\.", "", as.character(dim)))
   if (length(nm) > 1) {
-    expand <- rep(seq_len(dim(x)[maindim]), length(nm))
-    x <- x[expand, dim = maindim]
-    nm <- rep(nm, each = dim(x)[maindim] / length(nm))
+    if (expand) {
+      expansion <- rep(seq_len(dim(x)[maindim]), length(nm))
+      x <- x[expansion, dim = maindim]
+      nm <- rep(nm, each = dim(x)[maindim] / length(nm))
+    } else if (length(nm) != dim(x)[maindim]) {
+      stop("length(nm) != number of items already present in x in dim ", maindim,
+           "; actual numbers: ", length(nm), "!=", dim(x)[maindim])
+    }
   }
   if (is.null(getItems(x, dim = maindim))) {
     getItems(x, dim = maindim, raw = TRUE) <- nm

--- a/R/add_dimension.R
+++ b/R/add_dimension.R
@@ -10,7 +10,7 @@
 #' @param nm One or more names of items in the new dimension. If more than one
 #' is given, behavior depends on the expand argument.
 #' @param expand If TRUE, each item in nm is added to each item
-#' already present, resulting in e.g. `c("A.d1", "A.d2", "B.d1", "B.d2")`.
+#' already present, resulting in e.g. `c("A.d1", "B.d1", "A.d2", "B.d2")`.
 #' Otherwise, length of nm must equal the number of items already present and
 #' they are simply added, resulting in e.g. `c("A.d1", "B.d2")`.
 #'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.1.0**
+R package **magclass**, version **7.2.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.1.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.2.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -68,6 +68,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-12-04},
   year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.1.0},
+  note = {Version: 7.2.0},
 }
 ```

--- a/man/add_dimension.Rd
+++ b/man/add_dimension.Rd
@@ -4,7 +4,7 @@
 \alias{add_dimension}
 \title{add_dimension}
 \usage{
-add_dimension(x, dim = 3.1, add = NULL, nm = "dummy")
+add_dimension(x, dim = 3.1, add = NULL, nm = "dummy", expand = TRUE)
 }
 \arguments{
 \item{x}{MAgPIE object which should be extended.}
@@ -13,7 +13,13 @@ add_dimension(x, dim = 3.1, add = NULL, nm = "dummy")
 
 \item{add}{The name of the new dimension}
 
-\item{nm}{The name of the first entry in dimension "add".}
+\item{nm}{One or more names of items in the new dimension. If more than one
+is given, behavior depends on the expand argument.}
+
+\item{expand}{If TRUE, each item in nm is added to each item
+already present, resulting in e.g. `c("A.d1", "B.d1", "A.d2", "B.d2")`.
+Otherwise, length of nm must equal the number of items already present and
+they are simply added, resulting in e.g. `c("A.d1", "B.d2")`.}
 }
 \value{
 The extended MAgPIE object

--- a/tests/testthat/test-add_dimension.R
+++ b/tests/testthat/test-add_dimension.R
@@ -49,6 +49,15 @@ test_that("add_dimension works", {
   expect_identical(getItems(p, 3), c("a.b", "c.d"))
 })
 
+test_that("add_dimension's expand argument works", {
+  p <- maxample("pop")
+  p <- add_dimension(dimSums(p, 3), nm = c("a.b", "c.d"))
+  p2 <- add_dimension(p, nm = c("e", "f"), expand = FALSE)
+  expect_identical(getItems(p2, 3), c("e.a.b", "f.c.d"))
+  p3 <- add_dimension(p, nm = c("e", "f"), expand = TRUE)
+  expect_identical(getItems(p3, 3), c("e.a.b", "e.c.d", "f.a.b", "f.c.d"))
+})
+
 test_that("add_dimension works objects with inconsistent set information", {
   a <- maxample("animal")
   expect_silent(b <- add_dimension(a))


### PR DESCRIPTION
madrat::toolFixWeight is using a hard-to-read but faster workaround instead of add_dimension, but this is no longer necessary thanks to https://github.com/pik-piam/magclass/pull/193 and the small interface addition in this PR.
See also the corresponding madrat PR https://github.com/pik-piam/madrat/pull/275