### PR TITLE
performance improvements

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '15147060'
+ValidationKey: '14914630'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '14914630'
+ValidationKey: '15147060'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '14914630'
+ValidationKey: '15164820'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.4.0
-date-released: '2026-01-16'
+version: 7.3.0
+date-released: '2025-12-09'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.3.0
-date-released: '2025-12-09'
+version: 7.4.0
+date-released: '2026-02-09'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.3.0
-date-released: '2025-12-09'
+version: 7.4.0
+date-released: '2026-01-16'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0.9002
+Version: 7.3.0.9003
 Date: 2025-12-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0.9004
-Date: 2025-12-09
+Version: 7.4.0
+Date: 2026-02-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0
+Version: 7.3.0.9001
 Date: 2025-12-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0.9001
-Date: 2025-12-09
+Version: 7.4.0
+Date: 2026-01-16
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.4.0
-Date: 2026-01-16
+Version: 7.3.0.9001
+Date: 2025-12-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0.9003
+Version: 7.3.0.9004
 Date: 2025-12-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.3.0.9001
+Version: 7.3.0.9002
 Date: 2025-12-09
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),

--- a/R/magpie-class.R
+++ b/R/magpie-class.R
@@ -246,20 +246,16 @@ setClass("magpie", contains = "array", prototype = array(0, c(0, 0, 0)))
     return(nchar(gsub("[^\\.]", "", i)))
   }
   if (!is.list(i) && .countdots(i[1]) == .countdots(dimnames[1]) && pmatch == FALSE) {
-    stopifnot(identical(anyDuplicated(dimnames), anyDuplicated(as.data.table(dimnames)))) # TODO
     # i vector seems to specify the full dimname
     if (!anyDuplicated(dimnames)) {
       if (invert) {
         return(which(!(dimnames %in% i)))
-      # } else if (identical(i, dimnames)) { # TODO comment in
-      #   return(seq_along(i)) # TODO comment in
+      } else if (identical(i, dimnames)) {
+        return(seq_along(i))
       } else {
         match <- match(i, dimnames)
         if (any(is.na(match))) {
           stop("subscript out of bounds (\"", paste0(i[is.na(match)], collapse = "\", \""), "\")")
-        }
-        if (identical(i, dimnames)) {
-          stopifnot(identical(match, seq_along(i))) # TODO
         }
         return(match)
       }

--- a/R/magpie-class.R
+++ b/R/magpie-class.R
@@ -253,6 +253,8 @@ setClass("magpie", contains = "array", prototype = array(0, c(0, 0, 0)))
     if (!anyDuplicated(dimnames)) {
       if (invert) {
         return(which(!(dimnames %in% i)))
+      } else if (identical(i, dimnames)) {
+        return(seq_along(i))
       } else {
         match <- match(i, dimnames)
         if (any(is.na(match))) {

--- a/R/magpie-class.R
+++ b/R/magpie-class.R
@@ -246,8 +246,11 @@ setClass("magpie", contains = "array", prototype = array(0, c(0, 0, 0)))
     return(nchar(gsub("[^\\.]", "", i)))
   }
   if (!is.list(i) && .countdots(i[1]) == .countdots(dimnames[1]) && pmatch == FALSE) {
+    if (getOption("magclasstesting", FALSE)) {
+      stopifnot(identical(anyDuplicated(dimnames), anyDuplicated(as.data.table(dimnames))))
+    }
     # i vector seems to specify the full dimname
-    if (!anyDuplicated(as.data.table(dimnames))) {
+    if (!anyDuplicated(dimnames)) {
       if (invert) {
         return(which(!(dimnames %in% i)))
       } else {

--- a/R/magpie-class.R
+++ b/R/magpie-class.R
@@ -246,19 +246,20 @@ setClass("magpie", contains = "array", prototype = array(0, c(0, 0, 0)))
     return(nchar(gsub("[^\\.]", "", i)))
   }
   if (!is.list(i) && .countdots(i[1]) == .countdots(dimnames[1]) && pmatch == FALSE) {
-    if (getOption("magclasstesting", FALSE)) {
-      stopifnot(identical(anyDuplicated(dimnames), anyDuplicated(as.data.table(dimnames))))
-    }
+    stopifnot(identical(anyDuplicated(dimnames), anyDuplicated(as.data.table(dimnames)))) # TODO
     # i vector seems to specify the full dimname
     if (!anyDuplicated(dimnames)) {
       if (invert) {
         return(which(!(dimnames %in% i)))
-      } else if (identical(i, dimnames)) {
-        return(seq_along(i))
+      # } else if (identical(i, dimnames)) { # TODO comment in
+      #   return(seq_along(i)) # TODO comment in
       } else {
         match <- match(i, dimnames)
         if (any(is.na(match))) {
           stop("subscript out of bounds (\"", paste0(i[is.na(match)], collapse = "\", \""), "\")")
+        }
+        if (identical(i, dimnames)) {
+          stopifnot(identical(match, seq_along(i))) # TODO
         }
         return(match)
       }

--- a/R/magpie_expand.R
+++ b/R/magpie_expand.R
@@ -75,7 +75,7 @@ magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_lint
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # dimension is identical
       next
-    } else if (dim(x)[i] == dim(ref)[i] && setequal(dimnames(x)[[i]], dimnames(ref)[[i]]) &&
+    } else if (dim(x)[i] == dim(ref)[i] && testHelper(x, i, ref) &&
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # same length and entries, but different order
       x <- x[dimnames(ref)[[i]], dim = i]
@@ -85,4 +85,11 @@ magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_lint
   }
   getSets(x) <- make.unique(getSets(clean_magpie(x, what = "sets")), sep = "")
   return(x)
+}
+
+testHelper <- function(x, i, ref) {
+  original <- all(sort(dimnames(x)[[i]]) == sort(dimnames(ref)[[i]]))
+  out <- setequal(dimnames(x)[[i]], dimnames(ref)[[i]])
+  stopifnot(identical(original, out))
+  return(out)
 }

--- a/R/magpie_expand.R
+++ b/R/magpie_expand.R
@@ -40,6 +40,10 @@
 #' @export
 magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_linter.
 
+  if (identical(dimnames(x), dimnames(ref))) {
+    return(x)
+  }
+
   version <- getOption("magclass_expand_version")
   if (is.null(version)) options("magclass_expand_version" = 2.1) # nolint: undesirable_function_linter.
   if (!is.null(version) && version != 2.1) stop("Unsupported magclass expand version (", version, ")!")

--- a/R/magpie_expand.R
+++ b/R/magpie_expand.R
@@ -5,8 +5,7 @@
 #' Expansion means here that the dimensions of x are expanded accordingly to
 #' ref. Please note that this is really only about expansion. In the case that
 #' one dimension of ref is smaller than of x nothing happens with this
-#' dimension. At the moment magpie_expand is only internally available in the
-#' magclass library
+#' dimension.
 #'
 #' You can influence the verbosity of this function by setting the option
 #' "magclass.verbosity". By default verbosity is set to 1 which means that
@@ -39,10 +38,6 @@
 #' magpie_expand(b, a)
 #' @export
 magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_linter.
-
-  if (identical(dimnames(x), dimnames(ref))) {
-    return(x)
-  }
 
   version <- getOption("magclass_expand_version")
   if (is.null(version)) options("magclass_expand_version" = 2.1) # nolint: undesirable_function_linter.
@@ -80,7 +75,7 @@ magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_lint
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # dimension is identical
       next
-    } else if (dim(x)[i] == dim(ref)[i] && all(sort(dimnames(x)[[i]]) == sort(dimnames(ref)[[i]])) &&
+    } else if (dim(x)[i] == dim(ref)[i] && setequal(dimnames(x)[[i]], dimnames(ref)[[i]]) &&
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # same length and entries, but different order
       x <- x[dimnames(ref)[[i]], dim = i]

--- a/R/magpie_expand.R
+++ b/R/magpie_expand.R
@@ -75,7 +75,7 @@ magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_lint
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # dimension is identical
       next
-    } else if (dim(x)[i] == dim(ref)[i] && testHelper(x, i, ref) &&
+    } else if (dim(x)[i] == dim(ref)[i] && setequal(dimnames(x)[[i]], dimnames(ref)[[i]]) &&
                  (!setMatching || names(dimnames(x))[i] == names(dimnames(ref))[i])) {
       # same length and entries, but different order
       x <- x[dimnames(ref)[[i]], dim = i]
@@ -85,11 +85,4 @@ magpie_expand <- function(x, ref) { # nolint: object_name_linter, cyclocomp_lint
   }
   getSets(x) <- make.unique(getSets(clean_magpie(x, what = "sets")), sep = "")
   return(x)
-}
-
-testHelper <- function(x, i, ref) {
-  original <- all(sort(dimnames(x)[[i]]) == sort(dimnames(ref)[[i]]))
-  out <- setequal(dimnames(x)[[i]], dimnames(ref)[[i]])
-  stopifnot(identical(original, out))
-  return(out)
 }

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -41,7 +41,7 @@ magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
     attr(xd2, "row.names") <- attr(xd, "row.names")
     colnames(xd2) <- colnames(xd)
     for (i in seq_len(ncol(xd2))) {
-      names(xd2[[i]]) <- NULL
+      names(xd2[[i]]) <- names(xd[[i]])
     }
     stopifnot(identical(xd, xd2)) # TODO
 

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -27,15 +27,30 @@
 #'  magclass:::magpie_expand_dim(d, e, dim = 1)
 magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
 
-  if (!(dim %in% seq_len(3))) stop("Unsupported dim setting (dim = ", dim, ")")
+  if (!(dim %in% seq_len(3))) {
+    stop("Unsupported dim setting (dim = ", dim, ")")
+  }
 
   dimnames2df <- function(x, dim = 1) {
     splits <- strsplit(dimnames(x)[[dim]], ".", fixed = TRUE)
     xd <- data.frame(do.call(rbind, splits), stringsAsFactors = TRUE)
+
+
+    xd2 <- as.data.frame(t(as.data.frame(strsplit(dimnames(x)[[dim]], ".", fixed = TRUE), stringsAsFactors = TRUE)),
+                         stringsAsFactors = TRUE)
+    attr(xd2, "row.names") <- attr(xd, "row.names")
+    colnames(xd2) <- colnames(xd)
+    for (i in seq_len(ncol(xd2))) {
+      names(xd2[[i]]) <- NULL
+    }
+    stopifnot(identical(xd, xd2)) # TODO
+
     rownames(xd) <- NULL
     if (!is.null(names(dimnames(x)))) {
       tmp <- strsplit(names(dimnames(x))[dim], ".", fixed = TRUE)[[1]]
-      if (length(tmp) == ncol(xd)) names(xd) <- tmp
+      if (length(tmp) == ncol(xd)) {
+        names(xd) <- tmp
+      }
     }
     xd$".line" <- seq_len(nrow(xd))
     return(xd)
@@ -84,7 +99,9 @@ magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
              by = setdiff(intersect(names(dref), names(dx)), ".line"),
              all.x = TRUE, all.y = TRUE)
 
-  if (anyNA(c(m$.line_ref, m$.line_x))) stop(" Identical set names but different content. Correct set names!")
+  if (anyNA(c(m$.line_ref, m$.line_x))) {
+    stop(" Identical set names but different content. Correct set names!")
+  }
 
   # reorder m so that dref columns appear first
   m <- m[union(names(dref)[seq_len((ncol(dref) - 1))], names(m))]

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -30,8 +30,8 @@ magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
   if (!(dim %in% seq_len(3))) stop("Unsupported dim setting (dim = ", dim, ")")
 
   dimnames2df <- function(x, dim = 1) {
-    xd <- as.data.frame(t(as.data.frame(strsplit(dimnames(x)[[dim]], ".", fixed = TRUE), stringsAsFactors = TRUE)),
-                        stringsAsFactors = TRUE)
+    splits <- strsplit(dimnames(x)[[dim]], ".", fixed = TRUE)
+    xd <- data.frame(do.call(rbind, splits), stringsAsFactors = TRUE)
     rownames(xd) <- NULL
     if (!is.null(names(dimnames(x)))) {
       tmp <- strsplit(names(dimnames(x))[dim], ".", fixed = TRUE)[[1]]

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -38,12 +38,14 @@ magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
 
     xd2 <- as.data.frame(t(as.data.frame(strsplit(dimnames(x)[[dim]], ".", fixed = TRUE), stringsAsFactors = TRUE)),
                          stringsAsFactors = TRUE)
-    attr(xd2, "row.names") <- attr(xd, "row.names")
+    attr(xd2, "row.names") <- attr(xd, "row.names") # rownames would convert to character, but it might be integer
     colnames(xd2) <- colnames(xd)
+    xd3 <- xd # copy so we don't modify xd
     for (i in seq_len(ncol(xd2))) {
-      names(xd2[[i]]) <- names(xd[[i]])
+      names(xd2[[i]]) <- NULL
+      names(xd3[[i]]) <- NULL
     }
-    stopifnot(identical(xd, xd2)) # TODO
+    stopifnot(identical(xd3, xd2)) # TODO
 
     rownames(xd) <- NULL
     if (!is.null(names(dimnames(x)))) {

--- a/R/magpie_expand_dim.R
+++ b/R/magpie_expand_dim.R
@@ -35,18 +35,6 @@ magpie_expand_dim <- function(x, ref, dim = 1) { # nolint: object_name_linter.
     splits <- strsplit(dimnames(x)[[dim]], ".", fixed = TRUE)
     xd <- data.frame(do.call(rbind, splits), stringsAsFactors = TRUE)
 
-
-    xd2 <- as.data.frame(t(as.data.frame(strsplit(dimnames(x)[[dim]], ".", fixed = TRUE), stringsAsFactors = TRUE)),
-                         stringsAsFactors = TRUE)
-    attr(xd2, "row.names") <- attr(xd, "row.names") # rownames would convert to character, but it might be integer
-    colnames(xd2) <- colnames(xd)
-    xd3 <- xd # copy so we don't modify xd
-    for (i in seq_len(ncol(xd2))) {
-      names(xd2[[i]]) <- NULL
-      names(xd3[[i]]) <- NULL
-    }
-    stopifnot(identical(xd3, xd2)) # TODO
-
     rownames(xd) <- NULL
     if (!is.null(names(dimnames(x)))) {
       tmp <- strsplit(names(dimnames(x))[dim], ".", fixed = TRUE)[[1]]

--- a/R/mbind.R
+++ b/R/mbind.R
@@ -65,13 +65,8 @@ mbind <- function(...) { # nolint: cyclocomp_linter.
     }
     # Check which dimensions differ
     diffspat <- !setequal(dimnames(inputs[[1]])[[1]], dimnames(inputs[[i]])[[1]])
-    stopifnot(identical(diffspat, suppressWarnings(any(sort(dimnames(inputs[[1]])[[1]]) != sort(dimnames(inputs[[i]])[[1]]))))) # TODO
-
     difftemp <- !setequal(dimnames(inputs[[1]])[[2]], dimnames(inputs[[i]])[[2]])
-    stopifnot(identical(difftemp, suppressWarnings(any(sort(dimnames(inputs[[1]])[[2]]) != sort(dimnames(inputs[[i]])[[2]]))))) # TODO
-
     diffdata <- !setequal(dimnames(inputs[[1]])[[3]], dimnames(inputs[[i]])[[3]])
-    stopifnot(identical(diffdata, suppressWarnings(any(sort(dimnames(inputs[[1]])[[3]]) != sort(dimnames(inputs[[i]])[[3]]))))) # TODO
 
     years <- c(years, getYears(inputs[[i]]))
     elems <- c(elems, getNames(inputs[[i]]))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.4.0**
+R package **magclass**, version **7.3.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2026). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.4.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.3.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2026-01-16},
-  year = {2026},
+  date = {2025-12-09},
+  year = {2025},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.4.0},
+  note = {Version: 7.3.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.3.0**
+R package **magclass**, version **7.4.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.3.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2026). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.4.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-12-09},
-  year = {2025},
+  date = {2026-02-09},
+  year = {2026},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.3.0},
+  note = {Version: 7.4.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.3.0**
+R package **magclass**, version **7.4.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2025). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.3.0, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2026). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.4.0, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2025-12-09},
-  year = {2025},
+  date = {2026-01-16},
+  year = {2026},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.3.0},
+  note = {Version: 7.4.0},
 }
 ```

--- a/man/magpie_expand.Rd
+++ b/man/magpie_expand.Rd
@@ -21,8 +21,7 @@ Expands a MAgPIE object based on a reference
 Expansion means here that the dimensions of x are expanded accordingly to
 ref. Please note that this is really only about expansion. In the case that
 one dimension of ref is smaller than of x nothing happens with this
-dimension. At the moment magpie_expand is only internally available in the
-magclass library
+dimension.
 
 You can influence the verbosity of this function by setting the option
 "magclass.verbosity". By default verbosity is set to 1 which means that


### PR DESCRIPTION
The change from comparing sorted dimnames to setequal is factor 12 faster (6s vs 0.5s) in this test case:
```
pkgload::load_all()
s <- 10^6
# as.character converts 10000 to "1e+05" if only ranges (`:`) are passed to it
a <- new.magpie(c(1, 2:s))
b <- new.magpie(c(2:s, 1))
system.time({
  xa <- magpie_expand(a, b)
  stopifnot(identical(xa, b))
}) # 6s with sort, 0.5s with setequal

system.time({
  asd <- a[getItems(b, 1), , ]
}) # 0.27 -> 0.18 omit as.data.table in anyDuplicated(as.data.table(dimnames))

system.time({
  asd <- a[getItems(a, 1), , ]
}) # 0.18 -> 0.08 check identical before match

system.time({
  asd <- mbind(setNames(a, "a"), setNames(b, "b"))
}) # 12.56 -> 1.3 setequal instead of sort
```

Would not want to merge this PR without running a full preprocessing pipeline though, so the question is, should we look for other potential improvements to magpie_expand before starting this testing process?