### PR TITLE
Reduces memory usage of conversion from SpatRaster to magpie 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '15228808'
+ValidationKey: '15258991'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'magclass: Data Class and Tools for Handling Spatial-Temporal Data'
-version: 7.4.2
-date-released: '2026-03-12'
+version: 7.4.3
+date-released: '2026-03-25'
 abstract: Data class for increased interoperability working with spatial-temporal
   data together with corresponding functions and methods (conversions, basic calculations
   and basic data manipulation). The class distinguishes between spatial, temporal

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: magclass
 Title: Data Class and Tools for Handling Spatial-Temporal Data
-Version: 7.4.2
-Date: 2026-03-12
+Version: 7.4.3
+Date: 2026-03-25
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431")),

--- a/R/as.magpie.R
+++ b/R/as.magpie.R
@@ -2,7 +2,7 @@
 #' @importFrom data.table as.data.table tstrsplit melt
 
 #' @exportMethod as.magpie
-setGeneric("as.magpie", function(x, ...) standardGeneric("as.magpie"))
+setGeneric("as.magpie", function(x, ...) standardGeneric("as.magpie")) # nolint: object_name_linter
 
 setMethod("as.magpie", signature(x = "magpie"), function(x) return(x))
 
@@ -378,9 +378,12 @@ setMethod("as.magpie",
     idVars <- "id"
   }
 
-  df <- as.data.table(df)
+  setDT(df) # No copy is made, df is changed in-place to data.tabe
   df <- melt(df, id.vars = idVars)
-  variable <- as.data.table(tstrsplit(df$variable, "..", fixed = TRUE))
+
+  # We first only work on a sample to determine the proper
+  # variable names. Then we do the variable transformation in-place.
+  variable <- data.frame(tstrsplit(df$variable[1], "..", fixed = TRUE))
   if (!is.null(temporal)) temporal <- temporal + length(idVars)
   if (ncol(variable) == 1) {
     if (all(grepl("^[yX][0-9]*$", variable[[1]], perl = TRUE))) {
@@ -396,9 +399,14 @@ setMethod("as.magpie",
   } else {
     stop("Reserved dimension separator \"..\" occurred more than once in layer names! Cannot convert raster object")
   }
-  df <- as.data.frame(df)
-  baseDims <- which(!(colnames(df) %in% c("variable", "value")))
-  df <- cbind(df[, baseDims, drop = FALSE], variable, df[, "value", drop = FALSE])
+
+  # Now, we actually transform the variable columns
+  df[, names(variable) := tstrsplit(df$variable, "..", fixed = TRUE)]
+  df[, variable := NULL] # variable column is not needed anymore
+
+  baseDims <- colnames(df)[!(colnames(df) %in% c("value", names(variable)))]
+  setcolorder(df, neworder = c(baseDims, names(variable), "value"))
+  setDF(df)
   out <- tidy2magpie(df, spatial = idVars, temporal = temporal)
   if (!is.null(geometry)) {
     names(geometry) <- getItems(out, dim = 1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Class and Tools for Handling Spatial-Temporal Data
 
-R package **magclass**, version **7.4.2**
+R package **magclass**, version **7.4.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/magclass)](https://cran.r-project.org/package=magclass) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1158580.svg)](https://doi.org/10.5281/zenodo.1158580) [![R build status](https://github.com/pik-piam/magclass/workflows/check/badge.svg)](https://github.com/pik-piam/magclass/actions) [![codecov](https://codecov.io/gh/pik-piam/magclass/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/magclass) [![r-universe](https://pik-piam.r-universe.dev/badges/magclass)](https://pik-piam.r-universe.dev/builds)
 
@@ -56,7 +56,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **magclass** in publications use:
 
-Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2026). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.4.2, <https://github.com/pik-piam/magclass>.
+Dietrich J, Bodirsky B, Bonsch M, Humpenoeder F, Bi S, Karstens K, Leip D, Sauer P, Baumstark L, Bertram C, Giannousakis A, Klein D, Neher I, Pehl M, Schultes A, Stevanovic M, Wang X, Beier F, Pflüger M, Richters O, Rein P (2026). "magclass: Data Class and Tools for Handling Spatial-Temporal Data." doi:10.5281/zenodo.1158580 <https://doi.org/10.5281/zenodo.1158580>, Version: 7.4.3, <https://github.com/pik-piam/magclass>.
 
 A BibTeX entry for LaTeX users is
 
@@ -65,9 +65,9 @@ A BibTeX entry for LaTeX users is
   title = {magclass: Data Class and Tools for Handling Spatial-Temporal Data},
   author = {Jan Philipp Dietrich and Benjamin Leon Bodirsky and Markus Bonsch and Florian Humpenoeder and Stephen Bi and Kristine Karstens and Debbora Leip and Pascal Sauer and Lavinia Baumstark and Christoph Bertram and Anastasis Giannousakis and David Klein and Ina Neher and Michaja Pehl and Anselm Schultes and Miodrag Stevanovic and Xiaoxi Wang and Felicitas Beier and Mika Pflüger and Oliver Richters and Patrick Rein},
   doi = {10.5281/zenodo.1158580},
-  date = {2026-03-12},
+  date = {2026-03-25},
   year = {2026},
   url = {https://github.com/pik-piam/magclass},
-  note = {Version: 7.4.2},
+  note = {Version: 7.4.3},
 }
 ```


### PR DESCRIPTION
Mostly by doing more operations in-place instead of copying the temporary data.tables/data.frames.

~~Still needs a full pipeline test.~~ Full pipeline test was successful.

Full pipeline test shows that memory usage goes down from ~78 GB (which seemingly briefly goes beyond 80 GB limit) to 70 GB (which apparently gives enough leeway to not hit the limit). The question remains how we end up why the OS reports 70 GB (verified in top) while R `gc()` reports only around 30-40 GB peak.

Also bisecting to determine changes that increased overall usage that much still runs. 